### PR TITLE
chore: moving Jest configuration to common folder

### DIFF
--- a/configuration/jest.config.common.cjs
+++ b/configuration/jest.config.common.cjs
@@ -1,0 +1,26 @@
+module.exports = {
+	transform: {
+		"^.+\\.(t|j)s?$": [
+			"@swc/jest",
+			{
+				exclude: [],
+				swcrc: false,
+				jsc: {
+					parser: {
+						syntax: "typescript",
+					},
+					externalHelpers: true,
+				},
+			},
+		],
+	},
+	collectCoverageFrom: ["src/*.{js,mjs,jsx,ts,tsx}"],
+	coverageThreshold: {
+		global: {
+			branches: 100,
+			functions: 100,
+			lines: 100,
+			statements: 100,
+		},
+	},
+};

--- a/packages/logger/jest.config.cjs
+++ b/packages/logger/jest.config.cjs
@@ -1,28 +1,5 @@
+const commonJest = require("../../configuration/jest.config.common.cjs");
+
 module.exports = {
-	// coverageDirectory: "<rootDir>/../../coverage",
-	// roots: ["<rootDir>/../../packages/logger/src"],
-	transform: {
-		"^.+\\.(t|j)s?$": [
-			"@swc/jest",
-			{
-				exclude: [],
-				swcrc: false,
-				jsc: {
-					parser: {
-						syntax: "typescript",
-					},
-					externalHelpers: true,
-				},
-			},
-		],
-	},
-	collectCoverageFrom: ["src/*.{js,mjs,jsx,ts,tsx}"],
-	coverageThreshold: {
-		global: {
-			branches: 100,
-			functions: 100,
-			lines: 100,
-			statements: 100,
-		},
-	},
+	...commonJest,
 };


### PR DESCRIPTION
Same as with TS config, moving common Jest configuration to the `configuration` folder.