### PR TITLE
fix: better configuration for swc+esm+ts+jest

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,6 +5,7 @@ module.exports = {
 	plugins: ["@typescript-eslint"],
 	root: true,
 	rules: {
+		"unicorn/no-abusive-eslint-disable": 0,
 		"unicorn/no-console-spaces": 0,
 		"unicorn/filename-case": [
 			"error",

--- a/configuration/jest.before.all.cjs
+++ b/configuration/jest.before.all.cjs
@@ -1,2 +1,0 @@
-const kleur = require("kleur");
-kleur.enabled = false;

--- a/configuration/jest.config.common.cjs
+++ b/configuration/jest.config.common.cjs
@@ -6,6 +6,7 @@ module.exports = {
 				exclude: [],
 				swcrc: false,
 				jsc: {
+					target: "es2022",
 					parser: {
 						syntax: "typescript",
 					},
@@ -24,5 +25,8 @@ module.exports = {
 			statements: 100,
 		},
 	},
-	setupFilesAfterEnv: ["<rootDir>/../../configuration/jest.before.all.cjs"],
+	extensionsToTreatAsEsm: [".ts"],
+	moduleNameMapper: {
+		"(.+)\\.js": "$1",
+	},
 };

--- a/configuration/tsconfig.common.json
+++ b/configuration/tsconfig.common.json
@@ -31,18 +31,22 @@
 		 * relying on other imports.
 		 */
 		"isolatedModules": true,
+		/**
+		 * Specify a set of bundled library declaration files that
+		 * describe the target runtime environment.
+		 */
 		"lib": ["ESNext"],
 		/**
 		 * Specify what module code is generated.
 		 */
-		"module": "ESNext",
+		"module": "Node16",
 		/**
 		 * Specify the module resolution strategy:
 		 * - 'node' for Node.js’ CommonJS implementation
 		 * - 'node16' or 'nodenext' for Node.js’ ECMAScript Module Support
 		 *   from TypeScript 4.7 onwards
 		 */
-		"moduleResolution": "node",
+		"moduleResolution": "nodenext",
 		/**
 		 * Enable importing .json files
 		 */

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 		"packages/*"
 	],
 	"devDependencies": {
+		"@jest/globals": "29.5.0",
 		"@swc/cli": "^0.1.62",
 		"@swc/core": "^1.3.56",
 		"@swc/helpers": "^0.5.1",
@@ -13,7 +14,8 @@
 		"@types/node": "^20.1.0",
 		"@typescript-eslint/eslint-plugin": "^5.59.2",
 		"@typescript-eslint/parser": "^5.59.2",
-		"@types/fs-extra": "11.0.1",
+		"@types/fs-extra": "^11.0.1",
+		"cross-env": "^7.0.3",
 		"chokidar": "^3.5.3",
 		"eslint": "^8.40.0",
 		"eslint-config-prettier": "^8.8.0",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -20,7 +20,7 @@
 		"build:types": "tsc",
 		"clean": "rimraf dist types coverage",
 		"lint": "eslint \"src/*.ts\"",
-		"test": "jest",
+		"test": "cross-env-shell NODE_OPTIONS=--experimental-vm-modules jest",
 		"test:coverage": "npm run test -- --coverage",
 		"watch": "swc --watch --out-dir dist src"
 	},

--- a/packages/logger/src/__tests__/Logger.test.ts
+++ b/packages/logger/src/__tests__/Logger.test.ts
@@ -1,4 +1,6 @@
 import { Logger } from "../Logger";
+import { jest } from "@jest/globals";
+import kleur from "kleur";
 
 let mock = {
 		info: jest.fn(),
@@ -12,39 +14,16 @@ let mock = {
 	},
 	spyDate: any,
 	spyLocaleTime: any,
-	spyInfo: jest.SpyInstance<
-		void,
-		[message?: any, ...optionalParams: any[]],
-		any
-	>,
-	spyLog: jest.SpyInstance<
-		void,
-		[message?: any, ...optionalParams: any[]],
-		any
-	>,
-	spyDebug: jest.SpyInstance<
-		void,
-		[message?: any, ...optionalParams: any[]],
-		any
-	>,
-	spyWarn: jest.SpyInstance<
-		void,
-		[message?: any, ...optionalParams: any[]],
-		any
-	>,
-	spyError: jest.SpyInstance<
-		void,
-		[message?: any, ...optionalParams: any[]],
-		any
-	>,
-	spyExit: jest.SpyInstance<
-		void,
-		[message?: any, ...optionalParams: any[]],
-		any
-	>;
+	spyInfo: any,
+	spyLog: any,
+	spyDebug: any,
+	spyWarn: any,
+	spyError: any,
+	spyExit: any;
 
 describe("when testing with logging side-effects", () => {
 	beforeEach(() => {
+		kleur.enabled = false;
 		mock.info = jest.fn();
 		mock.log = jest.fn();
 		mock.debug = jest.fn();
@@ -206,6 +185,7 @@ describe("when testing with logging side-effects", () => {
  */
 describe("when testing for printErrorsAndExit with logging side-effects", () => {
 	beforeEach(() => {
+		kleur.enabled = false;
 		mock.log = jest.fn();
 		mock.warn = jest.fn();
 		mock.error = jest.fn();
@@ -234,7 +214,7 @@ describe("when testing for printErrorsAndExit with logging side-effects", () => 
 	});
 
 	it("should display the proper error messages but will not NOT exit", async () => {
-		const log = new Logger();
+		const log = new Logger({ boring: true });
 		log.printErrorsAndExit(["message one", "message two"]);
 		expect(mock.error).toHaveBeenCalledWith("message one");
 		expect(mock.error).toHaveBeenCalledWith("message two");

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -21,7 +21,7 @@
 		"build:types": "tsc",
 		"clean": "rimraf dist types coverage",
 		"lint": "eslint \"src/*.ts\"",
-		"test": "jest",
+		"test": "cross-env-shell NODE_OPTIONS=--experimental-vm-modules jest",
 		"test:coverage": "npm run test -- --coverage",
 		"watch": "swc --watch --out-dir dist src"
 	},

--- a/packages/static-server/src/server.ts
+++ b/packages/static-server/src/server.ts
@@ -69,9 +69,9 @@ const fastifyCacheOptions: {
 if (config.cache > 0) {
 	fastifyCacheOptions.expiresIn = config.cache;
 	fastifyCacheOptions.serverExpiresIn = config.cache;
-	fastifyCacheOptions.privacy = fastifyCache.privacy.PUBLIC;
+	fastifyCacheOptions.privacy = "public";
 } else {
-	fastifyCacheOptions.privacy = fastifyCache.privacy.NOCACHE;
+	fastifyCacheOptions.privacy = "no-cache";
 }
 
 fastify.register(fastifyCache, fastifyCacheOptions);

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,7 +574,7 @@
     jest-mock "^29.5.0"
     jest-util "^29.5.0"
 
-"@jest/globals@^29.5.0":
+"@jest/globals@29.5.0", "@jest/globals@^29.5.0":
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.5.0.tgz#6166c0bfc374c58268677539d0c181f9c1833298"
   integrity sha512-S02y0qMWGihdzNbUiqSAiKSpSozSuHX5UYc7QbnHP+D9Lyw8DgGGCinrN9uSuHPeKgSSzvPom2q1nAtBvUsvPQ==
@@ -1444,7 +1444,7 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
-"@types/fs-extra@11.0.1":
+"@types/fs-extra@^11.0.1":
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-11.0.1.tgz#f542ec47810532a8a252127e6e105f487e0a6ea5"
   integrity sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==
@@ -2745,6 +2745,13 @@ cosmiconfig@7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2754,7 +2761,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
- Pure ESM (source code, tests and generated code)
- Typescript (source code and tests)
- Types are generated
- Swc is used to build code and to transform code on the fly for tests
- Jest is used with Node optional option to support ESM
- Any code can import other modules
- Any code can use import.meta (which used to confuse Jest)