### PR TITLE
feat: expose showHelp method

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -6,7 +6,7 @@
 
 # API
 
-**parser(options) ⇒ { flags, parameters }**
+**parser(options) ⇒ { flags, parameters, showHelp }**
 
 ## Arguments
 
@@ -25,7 +25,8 @@
 
 ```js
 import { parser } from "@node-cli/parser";
-const { flags, parameters } = parser({
+
+const { flags, parameters, showHelp } = parser({
 	meta: import.meta, // this is required for --version to work correctly
 	examples: [
 		{
@@ -70,6 +71,10 @@ const { flags, parameters } = parser({
 		verbose: false,
 	},
 });
+
+// `flags` will be an object with what the user provided
+// `parameters` will be an object with what the user provided
+// `showHelp` is a method that can be invoked to display help instructions
 ```
 
 ## Note

--- a/packages/parser/src/__tests__/parser.test.ts
+++ b/packages/parser/src/__tests__/parser.test.ts
@@ -103,6 +103,17 @@ describe("when testing for meowHelpers with no logging side-effects", () => {
 	});
 
 	it("should return the right result from parser", async () => {
-		const { flags, parameters } = parser(parserOptions);
+		const { flags, parameters, showHelp } = parser(parserOptions);
+		expect(flags).toEqual({
+			boring: false,
+			dot: false,
+			help: false,
+			ignoreCase: false,
+			short: false,
+			stats: false,
+			version: false,
+		});
+		expect(parameters).toEqual({});
+		expect(showHelp).toBeInstanceOf(Function);
 	});
 });

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -47,6 +47,7 @@ export const parser = (configuration: ParserConfiguration) => {
 	meowParserHelper({ cli });
 
 	return {
+		showHelp: cli.showHelp,
 		flags: shallowMerge(defaultFlags, cli.flags),
 		parameters: shallowMerge(defaultParameters, cli.input),
 	};


### PR DESCRIPTION
While `showHelp` is internally automatically invoked when the user passes the `--help` flag, it is now exposed so that it can also be used and invoked non-automatically - for example if some combination of flags or parameters are invalid.