### PR TITLE
feat: moving common helpers under the "utilities" package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"@swc/helpers": "^0.5.1",
 		"@swc/jest": "^0.2.26",
 		"@types/jest": "^29.5.1",
+		"@types/lodash-es": "^4.17.7",
 		"@types/node": "^20.2.5",
 		"@types/node-notifier": "^8.0.2",
 		"@typescript-eslint/eslint-plugin": "^5.59.8",

--- a/packages/utilities/.swcrc
+++ b/packages/utilities/.swcrc
@@ -1,0 +1,14 @@
+{
+	"$schema": "http://json.schemastore.org/swcrc",
+	"exclude": ["test"],
+	"jsc": {
+		"target": "es2022",
+		"parser": {
+			"syntax": "typescript"
+		},
+		"externalHelpers": false
+	},
+	"module": {
+		"type": "es6"
+	}
+}

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -1,0 +1,64 @@
+# Node CLI Utilities
+
+![npm](https://img.shields.io/npm/v/@node-cli/utilities?label=version&logo=npm)
+
+> A few common utilities for Node CLI applications
+
+## Table of Content
+
+- [Table of Content](#table-of-content)
+- [Installation](#installation)
+- [API](#api)
+  - [lowerFirst](#lowerfirst)
+  - [uniqueID](#uniqueid)
+  - [upperFirst](#upperfirst)
+- [License](#license)
+
+## Installation
+
+```sh
+> cd your-project
+> npm install --save-dev @node-cli/utilities
+```
+
+## API
+
+### lowerFirst
+
+**lowerFirst(text: string) ⇒ `string`**
+
+Transform the first letter of the provided string to lowercase (but not all the words).
+
+```js
+import { lowerFirst } from "@node-cli/utilities";
+const str = lowerFirst("HELLO WORLD");
+// str is "hELLO WORLD"
+```
+
+### uniqueID
+
+**uniqueID(prefix?: string = "") ⇒ `string`**
+
+Generate a unique ID.
+
+```js
+import { uniqueID } from "@node-cli/utilities";
+const id = uniqueID("my-prefix-");
+// id is something like "my-prefix-5f3a2b3c-1a2b-3c4d-5e6f-7a8b9c0d1e2f"
+```
+
+### upperFirst
+
+**upperFirst(text: string) ⇒ `string`**
+
+Capitalize the first letter of the provided string (but not all the words).
+
+```js
+import { upperFirst } from "@node-cli/utilities";
+const str = upperFirst("hello world");
+// str is "Hello world"
+```
+
+## License
+
+MIT © Arno Versini

--- a/packages/utilities/jest.config.cjs
+++ b/packages/utilities/jest.config.cjs
@@ -1,0 +1,5 @@
+const commonJest = require("../../configuration/jest.config.common.cjs");
+
+module.exports = {
+	...commonJest,
+};

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@node-cli/utilities",
+	"version": "0.0.0",
+	"license": "MIT",
+	"author": "Arno Versini",
+	"description": "A few utilities for Node CLI applications",
+	"type": "module",
+	"types": "./dist/index.d.ts",
+	"exports": "./dist/utilities.js",
+	"files": [
+		"dist"
+	],
+	"node": ">=16",
+	"dependencies": {
+		"lodash-es": "^4.17.21"
+	},
+	"scripts": {
+		"build": "yarn run clean && yarn run build:types && yarn run build:js && yarn run build:barrel",
+		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",
+		"build:js": "swc --source-maps --out-dir dist src",
+		"build:types": "tsc",
+		"clean": "rimraf dist types coverage",
+		"lint": "prettier --write \"src/*.ts\" && eslint --fix \"src/*.ts\"",
+		"test": "cross-env-shell NODE_OPTIONS=--experimental-vm-modules jest",
+		"test:coverage": "npm run test -- --coverage",
+		"watch": "swc --watch --out-dir dist src"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/utilities/src/__tests__/utilities.test.ts
+++ b/packages/utilities/src/__tests__/utilities.test.ts
@@ -1,0 +1,50 @@
+import { lowerFirst, uniqueID, upperFirst } from "../utilities.js";
+
+describe("when testing for meowHelpers with no logging side-effects", () => {
+	it("should return a string with the first letter capitalized", () => {
+		expect(upperFirst("hello")).toBe("Hello");
+		expect(upperFirst("hEllo")).toBe("HEllo");
+		expect(upperFirst("Hello")).toBe("Hello");
+	});
+
+	it("should return a string with the first letter in lower case", () => {
+		expect(lowerFirst("Hello")).toBe("hello");
+		expect(lowerFirst("HEllo")).toBe("hEllo");
+		expect(lowerFirst("hello")).toBe("hello");
+	});
+
+	it("should return two unique random numbers in both dev and prod mode", () => {
+		const nodeEnvironment = process.env.NODE_ENV;
+		process.env.NODE_ENV = "production";
+		expect(uniqueID()).not.toEqual(uniqueID());
+		process.env.NODE_ENV = "development";
+		expect(uniqueID()).not.toEqual(uniqueID());
+
+		// Restore original node env.
+		process.env.NODE_ENV = nodeEnvironment;
+	});
+
+	it("should return two prefixed, unique random numbers in dev mode", () => {
+		const nodeEnvironment = process.env.NODE_ENV;
+		process.env.NODE_ENV !== "production";
+		const randomString1 = uniqueID("some-prefix-");
+		const randomString2 = uniqueID("some-prefix-");
+		expect(randomString1).toMatch(/some-prefix-\d+/);
+		expect(randomString1).not.toEqual(randomString2);
+
+		// Restore original node env.
+		process.env.NODE_ENV = nodeEnvironment;
+	});
+
+	it("should return two prefixed, unique random numbers in prod mode", () => {
+		const nodeEnvironment = process.env.NODE_ENV;
+		process.env.NODE_ENV = "production";
+		const randomString1 = uniqueID("some-prefix-");
+		const randomString2 = uniqueID("some-prefix-");
+		expect(randomString1).toMatch(/some-prefix-\d{10,}/);
+		expect(randomString1).not.toEqual(randomString2);
+
+		// Restore original node env.
+		process.env.NODE_ENV = nodeEnvironment;
+	});
+});

--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -1,0 +1,42 @@
+import { uniqueId } from "lodash-es";
+
+/**
+ * Converts the first character of string to upper case
+ * @param {string} string_ the string to convert
+ * @returns {string} the converted string
+ */
+export const upperFirst = (string_: string): string =>
+	string_[0].toUpperCase() + string_.slice(1);
+
+/**
+ * Converts the first character of string to lower case
+ * @param {string} string_ the string to convert
+ * @returns {string} the converted string
+ */
+export const lowerFirst = (string_: string): string =>
+	string_[0].toLowerCase() + string_.slice(1);
+
+/**
+ * Generate a random number to append to an `id` string.
+ *
+ * NOTE: we are still using the good old lodash uniqueId when
+ * the code is not in production, so that the results are a
+ * little bit more consistent tests after test instead of
+ * being completely random, so that they do not break
+ * potential snapshot tests.
+ *
+ * @param {String} prefix - When a prefix is provided, the
+ *                          function will return a random
+ *                          number appended to the provided
+ *                          prefix.
+ *
+ * @returns {String} - Returns a string with random numbers.
+ */
+export const uniqueID = (prefix: string = ""): string => {
+	if (process.env.NODE_ENV !== "production") {
+		return uniqueId(prefix);
+	}
+	// Extract the decimal part
+	const randomNumber = `${Math.random()}`.split(".")[1];
+	return prefix || prefix !== "" ? `${prefix}${randomNumber}` : randomNumber;
+};

--- a/packages/utilities/tsconfig.json
+++ b/packages/utilities/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": ["../../configuration/tsconfig.common.json"],
+	"compilerOptions": {
+		"declarationDir": "dist",
+		"outDir": "dist"
+	},
+	"include": ["src"],
+	"exclude": ["src/__tests__"]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
 		"packages/search": {},
 		"packages/secret": {},
 		"packages/static-server": {},
-		"packages/timer": {}
+		"packages/timer": {},
+		"packages/utilities": {}
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,6 +1510,18 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash-es@^4.17.7":
+  version "4.17.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.7.tgz#22edcae9f44aff08546e71db8925f05b33c7cc40"
+  integrity sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.195"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
+  integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
+
 "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -5357,6 +5369,11 @@ locate-path@^7.1.0:
   integrity sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==
   dependencies:
     p-locate "^6.0.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
# Node CLI Utilities

![npm](https://img.shields.io/npm/v/@node-cli/utilities?label=version&logo=npm)

> A few common utilities for Node CLI applications

## Table of Content

- [Table of Content](#table-of-content)
- [Installation](#installation)
- [API](#api)
  - [lowerFirst](#lowerfirst)
  - [uniqueID](#uniqueid)
  - [upperFirst](#upperfirst)
- [License](#license)

## Installation

```sh
> cd your-project
> npm install --save-dev @node-cli/utilities
```

## API

### lowerFirst

**lowerFirst(text: string) ⇒ `string`**

Transform the first letter of the provided string to lowercase (but not all the words).

```js
import { lowerFirst } from "@node-cli/utilities";
const str = lowerFirst("HELLO WORLD");
// str is "hELLO WORLD"
```

### uniqueID

**uniqueID(prefix?: string = "") ⇒ `string`**

Generate a unique ID.

```js
import { uniqueID } from "@node-cli/utilities";
const id = uniqueID("my-prefix-");
// id is something like "my-prefix-5f3a2b3c-1a2b-3c4d-5e6f-7a8b9c0d1e2f"
```

### upperFirst

**upperFirst(text: string) ⇒ `string`**

Capitalize the first letter of the provided string (but not all the words).

```js
import { upperFirst } from "@node-cli/utilities";
const str = upperFirst("hello world");
// str is "Hello world"
```

## License

MIT © Arno Versini
