### PR TITLE
feat: adding "fastMerge"

### DIFF
--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -10,6 +10,7 @@
 - [Installation](#installation)
 - [API](#api)
   - [lowerFirst](#lowerfirst)
+  - [fastMerge](#fastmerge)
   - [uniqueID](#uniqueid)
   - [upperFirst](#upperfirst)
 - [License](#license)
@@ -33,6 +34,43 @@ Transform the first letter of the provided string to lowercase (but not all the 
 import { lowerFirst } from "@node-cli/utilities";
 const str = lowerFirst("HELLO WORLD");
 // str is "hELLO WORLD"
+```
+
+### fastMerge
+
+**fastMerge(objA: object, objB: object, customizer: () => void) ⇒ `object`**
+
+Wrapper method for lodash `merge()` and `mergeWith()` methods.
+
+Without the `customizer` function, this method recursively merges own and inherited enumerable string keyed properties of source objects into the destination object. Source properties that resolve to undefined are skipped if a destination value exists. Array and plain object properties are merged recursively. Other objects and value types are overridden by assignment. Source objects are applied from left to right. Subsequent sources overwrite property assignments of previous sources.
+
+With the `customizer` function, the behavior is the same except that `customizer` is invoked to produce the merged values of the destination and source properties. If customizer returns undefined, merging is handled by the `fastMerge` instead. The customizer is invoked with six arguments: `(objValue, srcValue, key, object, source, stack)`
+
+**WARNING**: this method will mutate objA!
+
+```js
+import { fastMerge } from "@node-cli/utilities";
+
+const objA = { port: 123, cache: false, gzip: true };
+const objB = { port: 456, gzip: false };
+const objC = fastMerge(objA, objB);
+
+// objC is { port: 456, cache: false, gzip: false };
+```
+
+```js
+import { isArray } from "lodash-es";
+import { fastMerge } from "@node-cli/utilities";
+
+const objA = { a: [1], b: [2] };
+const objB = { a: [3], b: [4] };
+const objC = fastMerge(objA, objB, (objValue, srcValue) => {
+	if (isArray(objValue)) {
+		return objValue.concat(srcValue);
+	}
+});
+
+// objC is { 'a': [1, 3], 'b': [2, 4] };
 ```
 
 ### uniqueID

--- a/packages/utilities/src/__tests__/deepEqual.ts
+++ b/packages/utilities/src/__tests__/deepEqual.ts
@@ -1,0 +1,119 @@
+/* eslint-disable default-case */
+/* eslint-disable complexity */
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @providesModule areEqual
+ * @flow
+ */
+
+const aStackPool: any = [];
+const bStackPool: any = [];
+
+/**
+ * Checks if two values are equal. Values may be primitives, arrays, or objects.
+ * Returns true if both arguments have the same keys and values.
+ *
+ * @see http://underscorejs.org
+ * @copyright 2009-2013 Jeremy Ashkenas, DocumentCloud Inc.
+ * @license MIT
+ */
+function eq(a: any, b: any, aStack: any[], bStack: any[]) {
+	if (a === b) {
+		// Identical objects are equal. `0 === -0`, but they aren't identical.
+		return a !== 0 || 1 / a === 1 / b;
+	}
+	if (a === null || b === null) {
+		// a or b can be `null` or `undefined`
+		return false;
+	}
+	if (typeof a != "object" || typeof b != "object") {
+		return false;
+	}
+	const objectToString = Object.prototype.toString;
+	const className = objectToString.call(a);
+	if (className !== objectToString.call(b)) {
+		return false;
+	}
+	switch (className) {
+		case "[object String]": {
+			return a === String(b);
+		}
+		case "[object Number]": {
+			return Number.isNaN(a) || Number.isNaN(b) ? false : a === Number(b);
+		}
+		case "[object Date]":
+		case "[object Boolean]": {
+			return Number(a) === Number(b);
+		}
+		case "[object RegExp]": {
+			return (
+				a.source === b.source &&
+				a.global === b.global &&
+				a.multiline === b.multiline &&
+				a.ignoreCase === b.ignoreCase
+			);
+		}
+	}
+	// Assume equality for cyclic structures.
+	let length = aStack.length,
+		size = 0;
+	while (length--) {
+		if (aStack[length] === a) {
+			return bStack[length] === b;
+		}
+	}
+	aStack.push(a);
+	bStack.push(b);
+	// Recursively compare objects and arrays.
+	if (className === "[object Array]") {
+		size = a.length;
+		if (size !== b.length) {
+			return false;
+		}
+		// Deep compare the contents, ignoring non-numeric properties.
+		while (size--) {
+			if (!eq(a[size], b[size], aStack, bStack)) {
+				return false;
+			}
+		}
+	} else {
+		if (a.constructor !== b.constructor) {
+			return false;
+		}
+		if (a.hasOwnProperty("valueOf") && b.hasOwnProperty("valueOf")) {
+			return a.valueOf() === b.valueOf();
+		}
+		const keys = Object.keys(a);
+		if (keys.length !== Object.keys(b).length) {
+			return false;
+		}
+		for (const key of keys) {
+			if (!eq(a[key], b[key], aStack, bStack)) {
+				return false;
+			}
+		}
+	}
+	aStack.pop();
+	bStack.pop();
+	return true;
+}
+
+export function deepEqual(a?: any, b?: any) {
+	const aStack: any = aStackPool.length > 0 ? aStackPool.pop() : [];
+	const bStack = bStackPool.length > 0 ? bStackPool.pop() : [];
+	const result = eq(a, b, aStack, bStack);
+	if (aStack) {
+		aStack.length = 0;
+		aStackPool.push(aStack);
+	}
+	if (bStack) {
+		bStack.length = 0;
+		bStackPool.push(bStack);
+	}
+
+	return result;
+}

--- a/packages/utilities/src/__tests__/utilities.test.ts
+++ b/packages/utilities/src/__tests__/utilities.test.ts
@@ -1,6 +1,9 @@
-import { lowerFirst, uniqueID, upperFirst } from "../utilities.js";
+import { fastMerge, lowerFirst, uniqueID, upperFirst } from "../utilities.js";
+import { isArray, keyBy, merge, orderBy, values } from "lodash-es";
 
-describe("when testing for meowHelpers with no logging side-effects", () => {
+import { deepEqual } from "./deepEqual.js";
+
+describe("when testing for utilities with no logging side-effects", () => {
 	it("should return a string with the first letter capitalized", () => {
 		expect(upperFirst("hello")).toBe("Hello");
 		expect(upperFirst("hEllo")).toBe("HEllo");
@@ -46,5 +49,138 @@ describe("when testing for meowHelpers with no logging side-effects", () => {
 
 		// Restore original node env.
 		process.env.NODE_ENV = nodeEnvironment;
+	});
+
+	it("should return a new configuration with keys for objB replacing keys from objA with fastMerge", async () => {
+		const configDefault = {
+			cache: 0,
+			cors: false,
+			gzip: true,
+			headers: [
+				{
+					key1: "value1",
+				},
+				{
+					key2: "value2",
+				},
+			],
+			logs: false,
+			open: false,
+			path: process.cwd(),
+			port: 8080,
+		};
+		const configCustom = {
+			gzip: false,
+			headers: [
+				{
+					key1: "newValue1",
+				},
+			],
+			port: 8081,
+		};
+		expect(deepEqual(configDefault, configDefault)).toBe(true);
+		expect(deepEqual(configDefault, configCustom)).toBe(false);
+		/**
+		 * This method will alter the objects, so no way to test for their
+		 * equality AFTER the merge is done... Only thing we can do is test
+		 * that the end result gets the right values.
+		 */
+		const result: any = fastMerge(configDefault, configCustom);
+
+		expect(result.port).toBe(8081);
+		expect(result.cache).toBe(0);
+		expect(result.cors).toBe(false);
+		expect(result.gzip).toBe(false);
+		expect(result.logs).toBe(false);
+		expect(result.open).toBe(false);
+		expect(result.path).toBe(process.cwd());
+
+		expect(
+			deepEqual(result.headers, [{ key1: "newValue1" }, { key2: "value2" }])
+		).toBe(true);
+	});
+
+	it("should behave exactly as lodash.merge", async () => {
+		const object = {
+			a: [{ b: 2 }, { d: 4 }],
+		};
+		const other = {
+			a: [{ c: 3 }, { e: 5 }],
+		};
+		const result = fastMerge(object, other);
+		expect(
+			deepEqual(result, {
+				a: [
+					{ b: 2, c: 3 },
+					{ d: 4, e: 5 },
+				],
+			})
+		).toBe(true);
+	});
+
+	it("should return a new configuration with custom nexPossible", async () => {
+		const configA = {
+			bump: {
+				nextPossible: [
+					{
+						default: false,
+						type: "minor",
+					},
+				],
+			},
+		};
+		const configB = {
+			bump: {
+				nextPossible: [
+					{
+						default: true,
+						type: "minor",
+					},
+				],
+			},
+		};
+		expect(deepEqual(configA, configB)).toBe(false);
+		/**
+		 * This method will alter the objects, so no way to test for their
+		 * equality AFTER the merge is done... Only thing we can do is test
+		 * that the end result gets the right values.
+		 */
+		const result: any = fastMerge(
+			configA,
+			configB,
+			(defined: any, custom: any, key: string) => {
+				if (key === "nextPossible") {
+					return orderBy(
+						values(merge(keyBy(defined, "type"), keyBy(custom, "type"))),
+						["pos"]
+					);
+				}
+			}
+		);
+
+		expect(
+			deepEqual(result.bump.nextPossible, [
+				{
+					default: true,
+					type: "minor",
+				},
+			])
+		).toBe(true);
+	});
+
+	it("should behave exactly as lodash.mergeWith", async () => {
+		const object = { a: [1], b: [2] };
+		const other = { a: [3], b: [4] };
+		const result = fastMerge(
+			object,
+			other,
+			(objectValue: string | any[], sourceValue: any) => {
+				if (isArray(objectValue)) {
+					// eslint-disable-next-line unicorn/prefer-spread
+					return objectValue.concat(sourceValue);
+				}
+			}
+		);
+		expect(deepEqual(result, { a: [1, 3], b: [2, 4] })).toBe(true);
 	});
 });

--- a/packages/utilities/src/utilities.ts
+++ b/packages/utilities/src/utilities.ts
@@ -1,4 +1,4 @@
-import { uniqueId } from "lodash-es";
+import { merge, mergeWith, uniqueId } from "lodash-es";
 
 /**
  * Converts the first character of string to upper case
@@ -39,4 +39,34 @@ export const uniqueID = (prefix: string = ""): string => {
 	// Extract the decimal part
 	const randomNumber = `${Math.random()}`.split(".")[1];
 	return prefix || prefix !== "" ? `${prefix}${randomNumber}` : randomNumber;
+};
+
+/**
+ * Wrapper method for lodash `merge()` and `mergeWith()` methods.
+ *
+ * Without the `customizer` function, this method recursively merges own and inherited
+ * enumerable string keyed properties of source objects into the destination object.
+ * Source properties that resolve to undefined are skipped if a destination value exists.
+ * Array and plain object properties are merged recursively. Other objects and value
+ * types are overridden by assignment. Source objects are applied from left to right.
+ * Subsequent sources overwrite property assignments of previous sources.
+ *
+ * With the `customizer` function, the behavior is the same except that `customizer` is
+ * invoked to produce the merged values of the destination and source properties.
+ * If customizer returns undefined, merging is handled by the `fastMerge` instead.
+ * The customizer is invoked with six arguments: `(objValue, srcValue, key, object,
+ * source, stack)`
+ * @param {object} objectA
+ * @param {object} objectB
+ * @param {function} customizer
+ * @returns {object} !! WARNING: this method will mutate objectA
+ */
+export const fastMerge = (
+	objectA: any,
+	objectB: any,
+	customizer?: any
+): object => {
+	return typeof customizer === "function"
+		? mergeWith(objectA, objectB, customizer)
+		: merge(objectA, objectB);
 };


### PR DESCRIPTION
### fastMerge

**fastMerge(objA: object, objB: object, customizer: () => void) ⇒ `object`**

Wrapper method for lodash `merge()` and `mergeWith()` methods.

Without the `customizer` function, this method recursively merges own and inherited enumerable string keyed properties of source objects into the destination object. Source properties that resolve to undefined are skipped if a destination value exists. Array and plain object properties are merged recursively. Other objects and value types are overridden by assignment. Source objects are applied from left to right. Subsequent sources overwrite property assignments of previous sources.

With the `customizer` function, the behavior is the same except that `customizer` is invoked to produce the merged values of the destination and source properties. If customizer returns undefined, merging is handled by the `fastMerge` instead. The customizer is invoked with six arguments: `(objValue, srcValue, key, object, source, stack)`

**WARNING**: this method will mutate objA!

```js
import { fastMerge } from "@node-cli/utilities";

const objA = { port: 123, cache: false, gzip: true };
const objB = { port: 456, gzip: false };
const objC = fastMerge(objA, objB);

// objC is { port: 456, cache: false, gzip: false };
```

```js
import { isArray } from "lodash-es";
import { fastMerge } from "@node-cli/utilities";

const objA = { a: [1], b: [2] };
const objB = { a: [3], b: [4] };
const objC = fastMerge(objA, objB, (objValue, srcValue) => {
	if (isArray(objValue)) {
		return objValue.concat(srcValue);
	}
});

// objC is { 'a': [1, 3], 'b': [2, 4] };
```
