### PR TITLE
fix: do not overwrite existing results unless --force is used

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -16,7 +16,8 @@
 		"access": "restricted"
 	},
 	"scripts": {
-		"stats": "bundlesize -c bundlesize.config.js -p \"$npm_package_version\" --type compare",
-		"stats:pr": "bundlesize -c bundlesize.config.js -p \"$npm_package_version\" -o tmp/stats.json"
+		"stats:pr": "bundlesize -c bundlesize.config.js -p \"$npm_package_version\" -o tmp/stats.json",
+		"stats:release": "bundlesize -c bundlesize.config.js -p \"$npm_package_version\" -o stats/stats.json",
+		"stats:report": "bundlesize -c bundlesize.config.js -p \"$npm_package_version\" --type report"
 	}
 }

--- a/examples/stats/stats.json
+++ b/examples/stats/stats.json
@@ -1,28 +1,54 @@
 {
-	"0.0.7": {
-		"data/file.txt": {
-			"fileSize": 1281,
-			"fileSizeGzip": 1199,
-			"limit": "1.5 kB",
-			"passed": true
-		},
-		"data/file-with-extra.txt": {
-			"fileSize": 2264,
-			"fileSizeGzip": 2197,
-			"limit": "1.5 kB",
-			"passed": true
-		},
-		"data/other-file.txt": {
-			"fileSize": 3307,
-			"fileSizeGzip": 4217,
-			"limit": "1.5 kB",
-			"passed": true
-		},
-		"data/index-<hash>.md": {
-			"fileSize": 0,
-			"fileSizeGzip": 20,
-			"limit": "1.5 kB",
-			"passed": true
-		}
-	}
+  "0.0.7": {
+    "data/file.txt": {
+      "fileSize": 1281,
+      "fileSizeGzip": 1199,
+      "limit": "1.5 kB",
+      "passed": true
+    },
+    "data/file-with-extra.txt": {
+      "fileSize": 2264,
+      "fileSizeGzip": 2197,
+      "limit": "1.5 kB",
+      "passed": true
+    },
+    "data/other-file.txt": {
+      "fileSize": 3307,
+      "fileSizeGzip": 4217,
+      "limit": "1.5 kB",
+      "passed": true
+    },
+    "data/index-<hash>.md": {
+      "fileSize": 0,
+      "fileSizeGzip": 20,
+      "limit": "1.5 kB",
+      "passed": true
+    }
+  },
+  "0.0.8": {
+    "data/file.txt": {
+      "fileSize": 281,
+      "fileSizeGzip": 199,
+      "limit": "1.5 kB",
+      "passed": true
+    },
+    "data/file-with-extra.txt": {
+      "fileSize": 264,
+      "fileSizeGzip": 199,
+      "limit": "1.5 kB",
+      "passed": true
+    },
+    "data/other-file.txt": {
+      "fileSize": 307,
+      "fileSizeGzip": 219,
+      "limit": "1.5 kB",
+      "passed": true
+    },
+    "data/index-<hash>.md": {
+      "fileSize": 0,
+      "fileSizeGzip": 20,
+      "limit": "1.5 kB",
+      "passed": true
+    }
+  }
 }

--- a/packages/bundlesize/src/__tests__/getRawStats.test.ts
+++ b/packages/bundlesize/src/__tests__/getRawStats.test.ts
@@ -1,3 +1,4 @@
+import { IGNORE } from "../utilities.js";
 import { fileURLToPath } from "node:url";
 import { getRawStats } from "../getRawStats.js";
 import kleur from "kleur";
@@ -181,5 +182,17 @@ describe("when testing for getRawStats with no errors", () => {
 			pass: true,
 			prefix: "0.0.0",
 		});
+	});
+
+	it("should report report existing stats", async () => {
+		const result = await getRawStats({
+			flags: {
+				force: false,
+				prefix: "0.0.8",
+				output: "src/__tests__/fixtures/stats/current.json",
+				configuration: path.join(__dirname, "fixtures/configuration/basic.js"),
+			},
+		});
+		expect(result.outputFile).toBe(IGNORE);
 	});
 });

--- a/packages/bundlesize/src/bundlesize.ts
+++ b/packages/bundlesize/src/bundlesize.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /* istanbul ignore file */
 
+import { IGNORE, STDOUT } from "./utilities.js";
+
 import { Logger } from "@node-cli/logger";
-import { STDOUT } from "./utilities.js";
 import { config } from "./parse.js";
 import fs from "fs-extra";
 import { getRawStats } from "./getRawStats.js";
@@ -17,6 +18,10 @@ const log = new Logger({
 if (flags.type === "size") {
 	try {
 		const result = await getRawStats({ flags });
+
+		if (result.outputFile === IGNORE) {
+			process.exit(result.exitCode);
+		}
 
 		if (result.exitMessage !== "") {
 			log.error(result.exitMessage);

--- a/packages/bundlesize/src/defaults.ts
+++ b/packages/bundlesize/src/defaults.ts
@@ -5,4 +5,5 @@ export const defaultFlags = {
 	configuration: "",
 	silent: false,
 	type: "size",
+	force: false,
 };

--- a/packages/bundlesize/src/getRawStats.ts
+++ b/packages/bundlesize/src/getRawStats.ts
@@ -1,4 +1,5 @@
 import {
+	IGNORE,
 	STDOUT,
 	getOutputFile,
 	gzipSizeFromFileSync,
@@ -126,10 +127,22 @@ export const getRawStats = async ({ flags }): Promise<ReportStats> => {
 			 */
 		}
 	}
-	existingResults[prefix] = currentResults;
+
+	/**
+	 * If the prefix already exists in the output file,
+	 * - if --force flag is used, overwrite the existing results
+	 * - if --force flag is not used, ignore the new results and
+	 *   keep the existing ones.
+	 */
+	if (existingResults[prefix] !== undefined && flags.force === false) {
+		result.outputFile = IGNORE;
+	} else {
+		result.outputFile = outputFile;
+		existingResults[prefix] = currentResults;
+	}
 
 	result.prefix = prefix;
-	result.outputFile = outputFile;
+
 	result.exitCode = failed && flags.silent === false ? 1 : 0;
 	result.data = existingResults;
 	return result;

--- a/packages/bundlesize/src/parse.ts
+++ b/packages/bundlesize/src/parse.ts
@@ -10,6 +10,7 @@ export type Flags = {
 	prefix?: string;
 	silent?: boolean;
 	type?: "size" | "report";
+	force?: boolean;
 };
 
 export type Configuration = {
@@ -23,6 +24,12 @@ export const config: Configuration = parser({
 	meta: import.meta,
 	examples: [],
 	flags: {
+		force: {
+			shortFlag: "f",
+			description: "Overwrite existing results",
+			type: "boolean",
+			default: defaultFlags.force,
+		},
 		type: {
 			shortFlag: "t",
 			description: "Specify the type of output: size or report",

--- a/packages/bundlesize/src/utilities.ts
+++ b/packages/bundlesize/src/utilities.ts
@@ -5,6 +5,7 @@ import semver from "semver";
 import zlib from "node:zlib";
 
 export const STDOUT = "stdout";
+export const IGNORE = "ignore";
 const CWD = process.cwd();
 
 export const gzipSizeFromFileSync = (file: string): number => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `force` flag to overwrite existing results when analyzing bundle sizes.
  
- **Tests**
	- Added test coverage for the new `getRawStats` behavior with the `force` flag.

- **Bug Fixes**
	- Implemented a conditional check to prevent process continuation when certain output conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->