### PR TITLE
fix(envtools): missing pnpm lock

### DIFF
--- a/packages/bundlesize/package.json
+++ b/packages/bundlesize/package.json
@@ -13,7 +13,7 @@
 	],
 	"node": ">=18",
 	"scripts": {
-		"build": "yarn run clean && yarn run build:types && yarn run build:js && yarn run build:barrel",
+		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",
 		"build:js": "swc --source-maps --out-dir dist src",
 		"build:types": "tsc",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -16,7 +16,7 @@
 		"ora": "8.0.1"
 	},
 	"scripts": {
-		"build": "yarn run clean && yarn run build:types && yarn run build:js && yarn run build:barrel",
+		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",
 		"build:js": "swc --source-maps --out-dir dist src",
 		"build:types": "tsc",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -19,7 +19,7 @@
 		"meow": "13.2.0"
 	},
 	"scripts": {
-		"build": "yarn run clean && yarn run build:types && yarn run build:js && yarn run build:barrel",
+		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",
 		"build:js": "swc --source-maps --out-dir dist src",
 		"build:types": "tsc",

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -16,7 +16,7 @@
 		"@node-cli/utilities": ">=1.0.0"
 	},
 	"scripts": {
-		"build": "yarn run clean && yarn run build:types && yarn run build:js && yarn run build:barrel",
+		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",
 		"build:js": "swc --source-maps --out-dir dist src",
 		"build:types": "tsc",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -16,7 +16,7 @@
 		"kleur": "4.1.5"
 	},
 	"scripts": {
-		"build": "yarn run clean && yarn run build:types && yarn run build:js && yarn run build:barrel",
+		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",
 		"build:js": "swc --source-maps --out-dir dist src",
 		"build:types": "tsc",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -13,7 +13,7 @@
 	],
 	"node": ">=16",
 	"scripts": {
-		"build": "yarn run clean && yarn run build:types && yarn run build:js && yarn run build:barrel",
+		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",
 		"build:js": "swc --source-maps --out-dir dist src",
 		"build:types": "tsc",

--- a/packages/secret/package.json
+++ b/packages/secret/package.json
@@ -13,7 +13,7 @@
 	],
 	"node": ">=16",
 	"scripts": {
-		"build": "yarn run clean && yarn run build:types && yarn run build:js && yarn run build:barrel",
+		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",
 		"build:js": "swc --source-maps --out-dir dist src",
 		"build:types": "tsc",

--- a/packages/static-server/package.json
+++ b/packages/static-server/package.json
@@ -13,7 +13,7 @@
 	],
 	"node": ">=18",
 	"scripts": {
-		"build": "yarn run clean && yarn run build:types && yarn run build:js&& yarn run build:barrel",
+		"build": "npm-run-all clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",
 		"build:js": "swc --source-maps --out-dir dist src --copy-files",
 		"build:types": "tsc",

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -13,7 +13,7 @@
 	],
 	"node": ">=16",
 	"scripts": {
-		"build": "yarn run clean && yarn run build:types && yarn run build:js && yarn run build:barrel",
+		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",
 		"build:js": "swc --source-maps --out-dir dist src",
 		"build:types": "tsc",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -15,7 +15,7 @@
 		"lodash-es": "4.17.21"
 	},
 	"scripts": {
-		"build": "yarn run clean && yarn run build:types && yarn run build:js && yarn run build:barrel",
+		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",
 		"build:js": "swc --source-maps --out-dir dist src",
 		"build:types": "tsc",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,8 @@ importers:
         specifier: 7.6.0
         version: 7.6.0
 
+  packages/envtools: {}
+
   packages/logger:
     dependencies:
       boxen:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the project dependencies to include the `envtools` package.
- **Refactor**
	- Switched from using `yarn run` commands to `npm-run-all` for the build script in multiple packages, altering the build process control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->