### PR TITLE
fix(npmrc): cannot create profile if profile config does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"lint": "lerna run lint",
 		"lint-staged": "lint-staged --config \"./configuration/lint-staged.config.cjs\"",
 		"prepare": "husky",
-		"test": "lerna run test"
+		"test": "lerna run test",
+		"test:coverage": "lerna run test:coverage"
 	},
 	"devDependencies": {
 		"@versini/dev-dependencies-common": "3.2.2",

--- a/packages/npmrc/src/__tests__/utilities.test.ts
+++ b/packages/npmrc/src/__tests__/utilities.test.ts
@@ -142,27 +142,13 @@ describe("when testing with logging side-effects", () => {
 				),
 				homeLocation,
 			});
+			// cleanup on aisle 5
+			await fs.remove(homeLocation);
+
+			// assertions
 			expect(result).toEqual(0);
 			expect(mock.warn).toHaveBeenCalledWith(
 				expect.stringContaining("Profile 'perso' already exists..."),
-			);
-		});
-
-		it("should return 1 if the profile configuration is corrupted", async () => {
-			const homeLocation = path.join(os.tmpdir(), "home");
-			const result = await createProfile({
-				flags: { verbose: true },
-				profileName: "perso",
-				storeLocation: path.join(__dirname, "fixtures/npmrcs"),
-				storeConfig: path.join(
-					__dirname,
-					"fixtures/configuration/does-not-exist.json",
-				),
-				homeLocation,
-			});
-			expect(result).toEqual(1);
-			expect(mock.error).toHaveBeenCalledWith(
-				expect.stringContaining("Could not create profile"),
 			);
 		});
 	});
@@ -184,7 +170,63 @@ describe("when testing with logging side-effects", () => {
 				storeConfig: temporaryConfig,
 				homeLocation,
 			});
-			await fs.writeJson(temporaryConfig, {});
+			// cleanup on aisle 5
+			await fs.remove(homeLocation);
+			await fs.remove(temporaryConfig);
+			await fs.remove(temporaryStoreLocation);
+
+			// assertions
+			expect(result).toEqual(0);
+			expect(mock.log).toHaveBeenCalledWith(
+				expect.stringContaining("┌ Profiles ──────────────────┐"),
+			);
+			expect(mock.log).toHaveBeenCalledWith(
+				expect.stringContaining("Profile 'work' created"),
+			);
+		});
+
+		it("should return 0, even if the profile configuration is corrupted", async () => {
+			const homeLocation = path.join(os.tmpdir(), "home");
+			const temporaryConfig = path.join(os.tmpdir(), "corrupted-config.json");
+			await fs.outputFile(temporaryConfig, "corrupted");
+
+			const result = await createProfile({
+				flags: { verbose: true },
+				profileName: "perso",
+				storeLocation: path.join(__dirname, "fixtures/npmrcs"),
+				storeConfig: temporaryConfig,
+				homeLocation,
+			});
+
+			// cleanup on aisle 5
+			await fs.remove(temporaryConfig);
+			await fs.remove(homeLocation);
+			// assertions
+			expect(result).toEqual(0);
+			expect(mock.log).toHaveBeenCalledWith(
+				expect.stringContaining("Profile 'perso' created"),
+			);
+		});
+
+		it("should return 0, even if the profile configuration does not exist", async () => {
+			const homeLocation = path.join(os.tmpdir(), "home");
+			const temporaryConfig = path.join(os.tmpdir(), "does-not-exist.json");
+			const temporaryStoreLocation = path.join(os.tmpdir(), "npmrcs");
+			await fs.ensureFile(path.join(homeLocation, ".npmrc"));
+			await fs.ensureFile(path.join(homeLocation, ".yarnrc"));
+			const result = await createProfile({
+				flags: { verbose: true },
+				profileName: "work",
+				storeLocation: temporaryStoreLocation,
+				storeConfig: temporaryConfig,
+				homeLocation,
+			});
+			// cleanup on aisle 5
+			await fs.remove(homeLocation);
+			await fs.remove(temporaryConfig);
+			await fs.remove(temporaryStoreLocation);
+
+			// assertions
 			expect(result).toEqual(0);
 			expect(mock.log).toHaveBeenCalledWith(
 				expect.stringContaining("┌ Profiles ──────────────────┐"),
@@ -208,6 +250,10 @@ describe("when testing with logging side-effects", () => {
 				),
 				homeLocation,
 			});
+			// cleanup on aisle 5
+			await fs.remove(homeLocation);
+
+			// assertions
 			expect(result).toEqual(1);
 			expect(mock.error).toHaveBeenCalledWith(
 				expect.stringContaining("Profile 'does-not-exist' does not exist"),
@@ -226,6 +272,10 @@ describe("when testing with logging side-effects", () => {
 				),
 				homeLocation,
 			});
+			// cleanup on aisle 5
+			await fs.remove(homeLocation);
+
+			// assertions
 			expect(result).toEqual(0);
 			expect(mock.warn).toHaveBeenCalledWith(
 				expect.stringContaining("Profile 'perso' is already active"),
@@ -244,6 +294,10 @@ describe("when testing with logging side-effects", () => {
 				),
 				homeLocation,
 			});
+			// cleanup on aisle 5
+			await fs.remove(homeLocation);
+
+			// assertions
 			expect(result).toEqual(1);
 			expect(mock.error).toHaveBeenCalledWith(
 				expect.stringContaining("Could not switch profile"),
@@ -265,7 +319,11 @@ describe("when testing with logging side-effects", () => {
 				storeConfig: temporaryConfig,
 				homeLocation,
 			});
-			await fs.writeJson(temporaryConfig, {});
+			// cleanup on aisle 5
+			await fs.remove(homeLocation);
+			await fs.remove(temporaryConfig);
+
+			// assertions
 			expect(result).toEqual(0);
 			expect(mock.log).toHaveBeenCalledWith(
 				expect.stringContaining("Profile switched to 'perso'"),
@@ -285,7 +343,11 @@ describe("when testing with logging side-effects", () => {
 				storeConfig: temporaryConfig,
 				homeLocation,
 			});
-			await fs.writeJson(temporaryConfig, {});
+			// cleanup on aisle 5
+			await fs.remove(homeLocation);
+			await fs.remove(temporaryConfig);
+
+			// assertions
 			expect(result).toEqual(0);
 			expect(mock.warn).toHaveBeenCalledWith(
 				expect.stringContaining(
@@ -310,7 +372,11 @@ describe("when testing with logging side-effects", () => {
 				storeConfig: temporaryConfig,
 				homeLocation,
 			});
-			await fs.writeJson(temporaryConfig, {});
+			// cleanup on aisle 5
+			await fs.remove(homeLocation);
+			await fs.remove(temporaryConfig);
+
+			// assertions
 			expect(result).toEqual(0);
 			expect(mock.warn).toHaveBeenCalledWith(
 				expect.stringContaining(
@@ -386,7 +452,10 @@ describe("when testing with logging side-effects", () => {
 				storeLocation: path.join(os.tmpdir(), "fixtures/npmrcs"),
 				storeConfig: temporaryConfig,
 			});
-			await fs.writeJson(temporaryConfig, {});
+			// cleanup on aisle 5
+			await fs.remove(temporaryConfig);
+
+			// assertions
 			expect(result).toEqual(0);
 			expect(mock.log).toHaveBeenCalledWith(
 				expect.stringContaining("Profile 'perso' deleted"),

--- a/packages/npmrc/src/__tests__/utilities.test.ts
+++ b/packages/npmrc/src/__tests__/utilities.test.ts
@@ -133,7 +133,6 @@ describe("when testing with logging side-effects", () => {
 		it("should return 0 if profile already exists", async () => {
 			const homeLocation = path.join(os.tmpdir(), "home");
 			const result = await createProfile({
-				flags: { verbose: true },
 				profileName: "perso",
 				storeLocation: path.join(__dirname, "fixtures/npmrcs"),
 				storeConfig: path.join(
@@ -160,16 +159,18 @@ describe("when testing with logging side-effects", () => {
 			const temporaryStoreLocation = path.join(os.tmpdir(), "npmrcs");
 			await fs.writeJson(temporaryConfig, {
 				available: ["perso"],
+				enabled: "perso",
 			});
 			await fs.ensureFile(path.join(homeLocation, ".npmrc"));
 			await fs.ensureFile(path.join(homeLocation, ".yarnrc"));
 			const result = await createProfile({
-				flags: { verbose: true },
 				profileName: "work",
 				storeLocation: temporaryStoreLocation,
 				storeConfig: temporaryConfig,
 				homeLocation,
 			});
+			const config = await fs.readJSON(temporaryConfig);
+
 			// cleanup on aisle 5
 			await fs.remove(homeLocation);
 			await fs.remove(temporaryConfig);
@@ -177,6 +178,10 @@ describe("when testing with logging side-effects", () => {
 
 			// assertions
 			expect(result).toEqual(0);
+			expect(config).toStrictEqual({
+				available: ["perso", "work"],
+				enabled: "perso",
+			});
 			expect(mock.log).toHaveBeenCalledWith(
 				expect.stringContaining("┌ Profiles ──────────────────┐"),
 			);
@@ -191,7 +196,6 @@ describe("when testing with logging side-effects", () => {
 			await fs.outputFile(temporaryConfig, "corrupted");
 
 			const result = await createProfile({
-				flags: { verbose: true },
 				profileName: "perso",
 				storeLocation: path.join(__dirname, "fixtures/npmrcs"),
 				storeConfig: temporaryConfig,
@@ -215,12 +219,13 @@ describe("when testing with logging side-effects", () => {
 			await fs.ensureFile(path.join(homeLocation, ".npmrc"));
 			await fs.ensureFile(path.join(homeLocation, ".yarnrc"));
 			const result = await createProfile({
-				flags: { verbose: true },
 				profileName: "work",
 				storeLocation: temporaryStoreLocation,
 				storeConfig: temporaryConfig,
 				homeLocation,
 			});
+			const config = await fs.readJSON(temporaryConfig);
+
 			// cleanup on aisle 5
 			await fs.remove(homeLocation);
 			await fs.remove(temporaryConfig);
@@ -228,6 +233,10 @@ describe("when testing with logging side-effects", () => {
 
 			// assertions
 			expect(result).toEqual(0);
+			expect(config).toStrictEqual({
+				available: ["work"],
+				enabled: "work",
+			});
 			expect(mock.log).toHaveBeenCalledWith(
 				expect.stringContaining("┌ Profiles ──────────────────┐"),
 			);

--- a/packages/npmrc/src/npmrc.ts
+++ b/packages/npmrc/src/npmrc.ts
@@ -19,7 +19,6 @@ const { parameters, flags, showHelp } = config;
 
 if (flags.create && parameters !== undefined) {
 	const exitFlag = await createProfile({
-		flags,
 		storeConfig: NPMRC_STORE_CONFIG,
 		storeLocation: NPMRC_STORE,
 		profileName: parameters["0"],

--- a/packages/npmrc/src/utilities.ts
+++ b/packages/npmrc/src/utilities.ts
@@ -41,58 +41,49 @@ export const listProfiles = async ({ flags, storeConfig }) => {
 };
 
 export const createProfile = async ({
-	flags,
 	storeConfig,
 	storeLocation,
 	profileName,
 	homeLocation,
 }) => {
+	let profiles = { available: [], enabled: undefined };
+	await fs.ensureFile(storeConfig);
 	try {
-		let profiles = { available: [], enabled: undefined };
-		await fs.ensureFile(storeConfig);
-		try {
-			// if the profile already exists, do nothing
-			profiles = await fs.readJson(storeConfig);
-			if (profiles.available.includes(profileName)) {
-				logger.warn(`Profile '${profileName}' already exists...`);
-				return 0;
-			}
-		} catch {
-			// ignoring error since we are creating the file
+		// if the profile already exists, do nothing
+		profiles = await fs.readJson(storeConfig);
+		if (profiles.available.includes(profileName)) {
+			logger.warn(`Profile '${profileName}' already exists...`);
+			return 0;
 		}
-
-		// if the profile does not exist, create
-		// a folder named as the profile under the storeLocation folder,
-		// with the existing npmrc / yarnrc files
-		await fs.ensureDir(`${storeLocation}/${profileName}`);
-		// copy the existing npmrc / yarnrc files to the new folder
-		const NPMRC = `${homeLocation}/.npmrc`;
-		const YARNRC = `${homeLocation}/.yarnrc`;
-		if (await fs.pathExists(YARNRC)) {
-			await fs.copy(YARNRC, `${storeLocation}/${profileName}/yarnrc`);
-		}
-		if (await fs.pathExists(NPMRC)) {
-			await fs.copy(NPMRC, `${storeLocation}/${profileName}/npmrc`);
-		}
-		// then add the profile to the configuration file
-		const newProfiles = {
-			available: [...profiles.available, profileName],
-			enabled: profiles.enabled,
-		};
-		await fs.writeJson(storeConfig, newProfiles, { spaces: 2 });
-		logger.printBox(`Profile '${profileName}' created`, {
-			textAlignment: "left",
-			title: "Profiles",
-			borderColor: "blue",
-		});
-		return 0;
-	} catch (error) {
-		if (flags.verbose) {
-			logger.log(error);
-		}
-		logger.error("Could not create profile");
-		return 1;
+	} catch {
+		// ignoring error since we are creating the file
 	}
+
+	// if the profile does not exist, create
+	// a folder named as the profile under the storeLocation folder,
+	// with the existing npmrc / yarnrc files
+	await fs.ensureDir(`${storeLocation}/${profileName}`);
+	// copy the existing npmrc / yarnrc files to the new folder
+	const NPMRC = `${homeLocation}/.npmrc`;
+	const YARNRC = `${homeLocation}/.yarnrc`;
+	if (await fs.pathExists(YARNRC)) {
+		await fs.copy(YARNRC, `${storeLocation}/${profileName}/yarnrc`);
+	}
+	if (await fs.pathExists(NPMRC)) {
+		await fs.copy(NPMRC, `${storeLocation}/${profileName}/npmrc`);
+	}
+	// then add the profile to the configuration file
+	const newProfiles = {
+		available: [...profiles.available, profileName],
+		enabled: profiles.enabled ?? profileName,
+	};
+	await fs.writeJson(storeConfig, newProfiles, { spaces: 2 });
+	logger.printBox(`Profile '${profileName}' created`, {
+		textAlignment: "left",
+		title: "Profiles",
+		borderColor: "blue",
+	});
+	return 0;
 };
 
 export const switchProfile = async ({

--- a/packages/npmrc/src/utilities.ts
+++ b/packages/npmrc/src/utilities.ts
@@ -48,12 +48,19 @@ export const createProfile = async ({
 	homeLocation,
 }) => {
 	try {
-		const profiles = await fs.readJson(storeConfig);
-		// if the profile already exists, do nothing
-		if (profiles.available.includes(profileName)) {
-			logger.warn(`Profile '${profileName}' already exists...`);
-			return 0;
+		let profiles = { available: [], enabled: undefined };
+		await fs.ensureFile(storeConfig);
+		try {
+			// if the profile already exists, do nothing
+			profiles = await fs.readJson(storeConfig);
+			if (profiles.available.includes(profileName)) {
+				logger.warn(`Profile '${profileName}' already exists...`);
+				return 0;
+			}
+		} catch {
+			// ignoring error since we are creating the file
 		}
+
 		// if the profile does not exist, create
 		// a folder named as the profile under the storeLocation folder,
 		// with the existing npmrc / yarnrc files


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Added new test cases for profile creation.
	- Introduced cleanup steps after test execution.
- **Bug Fixes**
	- Improved handling of existing profiles in the profile creation process.
- **Chores**
	- Added a new script for running test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->