### PR TITLE
feat(npmrc): listing registries associated with the current profile

### DIFF
--- a/packages/npmrc/README.md
+++ b/packages/npmrc/README.md
@@ -12,25 +12,25 @@
 
 ## Examples
 
-List existing profiles
-
-```sh
-> npmrc -l
-```
-
-Create a profile
+Create a profile from the current .npmrc file
 
 ```sh
 > npmrc -c my-profile
 ```
 
-Switch to an existing profile
+List profiles handled by npmrc
+
+```sh
+> npmrc -l
+```
+
+Switch to an existing profile handled by npmrc
 
 ```sh
 > npmrc my-profile
 ```
 
-Delete a profile
+Delete a profile handled by npmrc
 
 ```sh
 > npmrc -d my-profile

--- a/packages/npmrc/package.json
+++ b/packages/npmrc/package.json
@@ -27,6 +27,7 @@
 	"dependencies": {
 		"@node-cli/logger": "workspace:../logger",
 		"@node-cli/parser": "workspace:../parser",
+		"@node-cli/run": "workspace:../run",
 		"fs-extra": "11.2.0",
 		"kleur": "4.1.5"
 	},

--- a/packages/npmrc/src/__tests__/utilities.test.ts
+++ b/packages/npmrc/src/__tests__/utilities.test.ts
@@ -133,7 +133,7 @@ describe("when testing with logging side-effects", () => {
 			});
 			expect(result).toEqual(0);
 			expect(mock.log).toHaveBeenCalledWith(
-				expect.stringContaining("┌ Profiles ────────────┐"),
+				expect.stringContaining("┌ Profiles"),
 			);
 			expect(mock.log).toHaveBeenCalledWith(expect.stringContaining("perso"));
 			expect(mock.log).toHaveBeenCalledWith(expect.stringContaining("work"));

--- a/packages/npmrc/src/utilities.ts
+++ b/packages/npmrc/src/utilities.ts
@@ -11,7 +11,6 @@ export const listProfiles = async ({ flags, storeConfig }) => {
 		const profiles = await fs.readJson(storeConfig);
 
 		if (profiles?.available?.length > 0) {
-			//
 			const activeProfile = profiles.enabled;
 			const messages =
 				activeProfile === undefined

--- a/packages/npmrc/src/utilities.ts
+++ b/packages/npmrc/src/utilities.ts
@@ -1,6 +1,7 @@
 import { Logger } from "@node-cli/logger";
 import fs from "fs-extra";
 import kleur from "kleur";
+import { run } from "@node-cli/run";
 
 export const logger = new Logger();
 logger.boring = process.env.NODE_ENV === "test";
@@ -10,11 +11,31 @@ export const listProfiles = async ({ flags, storeConfig }) => {
 		const profiles = await fs.readJson(storeConfig);
 
 		if (profiles?.available?.length > 0) {
+			//
 			const activeProfile = profiles.enabled;
 			const messages =
 				activeProfile === undefined
 					? []
 					: [kleur.green(`★ ${activeProfile} (active)`)];
+
+			/**
+			 * Since there is an active profile, we can check the
+			 * global registry and list it, alongside the active profile.
+			 */
+			if (activeProfile) {
+				const { stdout, stderr } = await run(
+					'npm config list -l -g | grep "registry ="',
+					{
+						ignoreError: true,
+					},
+				);
+				if (!stderr) {
+					const stdoutArray = (stdout as string)
+						.split("\n")
+						.map((line) => kleur.grey(`   • ${line}`));
+					messages.push(...stdoutArray);
+				}
+			}
 
 			for (const profile of profiles.available) {
 				if (profile !== activeProfile) {
@@ -56,7 +77,7 @@ export const createProfile = async ({
 			return 0;
 		}
 	} catch {
-		// ignoring error since we are creating the file
+		// ignoring error since we are going to create the file
 	}
 
 	// if the profile does not exist, create

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       '@node-cli/parser':
         specifier: workspace:../parser
         version: link:../parser
+      '@node-cli/run':
+        specifier: workspace:../run
+        version: link:../run
       fs-extra:
         specifier: 11.2.0
         version: 11.2.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the README.md with corrected sequence of actions for profile management and improved descriptions.
- **New Features**
	- Enhanced profile listing to include the global registry alongside the active profile.
- **Bug Fixes**
	- Adjusted a test assertion to more accurately reflect expected logging behavior.
- **Chores**
	- Added a new dependency `@node-cli/run` to improve functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->