### PR TITLE
fix(logger): printBox does not respect the boring option

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -137,10 +137,10 @@ export class Logger {
 		 * Setting some sensible Boxen options if
 		 * not provided by the user.
 		 */
+		const borderColor = options.borderColor || "yellow";
 		const boxenOptions: BoxenOptions = {
 			...options,
-			borderColor:
-				options.borderColor || (this.#printOptions.colors ? "yellow" : "white"),
+			borderColor: this.#printOptions.colors ? borderColor : "white",
 			padding: typeof options.padding === "number" ? options.padding : 1,
 			textAlignment: options.textAlignment || "center",
 		};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the visual presentation of logs by refining the border color assignment based on user settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->