### PR TITLE
feat(run): adding option to stream output while the command runs

### DIFF
--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -26,11 +26,12 @@ Runs a shell command asynchronously and returns both `stdout` and `stderr`. If t
 
 ### Arguments
 
-| Argument            | Type    | Default |
-| ------------------- | ------- | ------- |
-| command             | String  | ""      |
-| options             | Object  | { }     |
-| options.ignoreError | Boolean | false   |
+| Argument             | Type    | Default |
+| -------------------- | ------- | ------- |
+| command              | String  | ""      |
+| options              | Object  | { }     |
+| options.ignoreError  | Boolean | false   |
+| options.streamOutput | Boolean | false   |
 
 ### Note
 
@@ -38,18 +39,37 @@ If `ignoreError` is used, the method will not throw but will instead return an o
 
 #### Examples
 
+##### Basic usage
+
 ```js
 import { run } from "@node-cli/run";
-const { stdout, stderr } = await run("npm config ls");
+const { stdout, stderr } = await run("npm run build");
+```
+
+##### Multiple commands
+
+```js
+import { run } from "@node-cli/run";
 const { stdout, stderr } = await run(
-	"git add -A && git commit -a -m 'First commit'"
+  "git add -A && git commit -a -m 'First commit'"
 );
 ```
+
+##### Stream output
+
+```js
+import { run } from "@node-cli/run";
+await run("npm run build", {
+  streamOutput: true
+});
+```
+
+##### Ignore error
 
 ```js
 import { run } from "@node-cli/run";
 const { exitCode, shortMessage } = await runCommand("ls /not-a-folder", {
-	ignoreError: true,
+  ignoreError: true
 });
 // -> exitCode is 1 and shortMessage is "Command failed with exit code 1: ls /not-a-folder"
 ```

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -7,9 +7,7 @@
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": "./dist/run.js",
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"node": ">=16",
 	"dependencies": {
 		"execa": "9.1.0",
@@ -24,6 +22,8 @@
 		"lint": "biome lint src",
 		"test": "cross-env-shell NODE_OPTIONS=--experimental-vm-modules jest",
 		"test:coverage": "npm run test -- --coverage",
+		"test:echo": "echo \"testing testing\"",
+		"test:watch": "npm run test -- --watch",
 		"watch": "swc --strip-leading-paths --watch --out-dir dist src"
 	},
 	"publishConfig": {

--- a/packages/run/src/__tests__/index.test.ts
+++ b/packages/run/src/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import { run } from "../run";
+import { parseCommandString } from "../utilities";
 
 describe("when testing for run utilities with no logging side-effects", () => {
 	it("should return the command output via stdout", async () => {
@@ -15,18 +16,12 @@ describe("when testing for run utilities with no logging side-effects", () => {
 
 	it("should throw an error if the command fails", async () => {
 		await expect(run("not-a-command")).rejects.toBeTruthy();
-	});
-
-	it("should throw an error if the command fails", async () => {
 		await expect(run("")).rejects.toBeTruthy();
-	});
-
-	it("should throw an error if the command fails", async () => {
 		// @ts-expect-error
 		await expect(run(666)).rejects.toBeTruthy();
 	});
 
-	it("should not throw an error even if the command does not exist", async () => {
+	it("should not throw an error, even if the command does not exist", async () => {
 		expect.assertions(1);
 		const result = await run("not-a-command", {
 			ignoreError: true,
@@ -66,5 +61,44 @@ describe("when testing for run utilities with no logging side-effects", () => {
 		const { stdout, stderr } = await run('echo "hello world"');
 		expect(stdout).toBe('"hello world"');
 		expect(stderr).toBe("");
+	});
+});
+
+describe("parseCommandString", () => {
+	it("should return an empty array for an empty command", () => {
+		expect(parseCommandString("")).toEqual([]);
+	});
+
+	it("should handle commands with only spaces", () => {
+		expect(parseCommandString("   ")).toEqual([]);
+	});
+
+	it("should split normal commands by spaces", () => {
+		expect(parseCommandString("echo hello world")).toEqual([
+			"echo",
+			"hello",
+			"world",
+		]);
+	});
+
+	it("should not split on escaped spaces", () => {
+		expect(parseCommandString("echo hello\\ world")).toEqual([
+			"echo",
+			"hello world",
+		]);
+	});
+
+	it("should handle multiple escaped spaces", () => {
+		expect(parseCommandString("path\\ to\\ some\\ file")).toEqual([
+			"path to some file",
+		]);
+	});
+
+	it("should handle mixed escaped and unescaped spaces", () => {
+		expect(parseCommandString("echo this\\ is\\ a test")).toEqual([
+			"echo",
+			"this is a",
+			"test",
+		]);
 	});
 });

--- a/packages/run/src/__tests__/index.test.ts
+++ b/packages/run/src/__tests__/index.test.ts
@@ -2,8 +2,8 @@ import { run } from "../run";
 
 describe("when testing for run utilities with no logging side-effects", () => {
 	it("should return the command output via stdout", async () => {
-		const { stdout, stderr } = await run("echo hello");
-		expect(stdout).toBe("hello");
+		const { stdout, stderr } = await run("echo hello world");
+		expect(stdout).toBe("hello world");
 		expect(stderr).toBe("");
 	});
 
@@ -15,6 +15,15 @@ describe("when testing for run utilities with no logging side-effects", () => {
 
 	it("should throw an error if the command fails", async () => {
 		await expect(run("not-a-command")).rejects.toBeTruthy();
+	});
+
+	it("should throw an error if the command fails", async () => {
+		await expect(run("")).rejects.toBeTruthy();
+	});
+
+	it("should throw an error if the command fails", async () => {
+		// @ts-expect-error
+		await expect(run(666)).rejects.toBeTruthy();
 	});
 
 	it("should not throw an error even if the command does not exist", async () => {
@@ -31,7 +40,6 @@ describe("when testing for run utilities with no logging side-effects", () => {
 	});
 
 	it("should not throw an error even if the command fails", async () => {
-		expect.assertions(2);
 		const result = await run("ls /no-existing-folder", {
 			ignoreError: true,
 		});
@@ -39,5 +47,24 @@ describe("when testing for run utilities with no logging side-effects", () => {
 		expect(result.shortMessage).toBe(
 			`Command failed with exit code ${result.exitCode}: ls /no-existing-folder`,
 		);
+	});
+
+	it("should be able to run a command with a pipe", async () => {
+		const { stdout, stderr } = await run("echo hello | wc -l");
+		const lines = typeof stdout === "string" ? stdout.trim() : stdout;
+		expect(lines).toBe("1");
+		expect(stderr).toBe("");
+	});
+
+	it("should be able to run a command with single quote", async () => {
+		const { stdout, stderr } = await run("echo 'hello world'");
+		expect(stdout).toBe("'hello world'");
+		expect(stderr).toBe("");
+	});
+
+	it("should be able to run a command with double quote", async () => {
+		const { stdout, stderr } = await run('echo "hello world"');
+		expect(stdout).toBe('"hello world"');
+		expect(stderr).toBe("");
 	});
 });

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -1,26 +1,6 @@
 import { execa, execaCommand } from "execa";
 import kleur from "kleur";
-
-const SPACES_REGEXP = / +/g;
-const parseCommandString = (command: string) => {
-	const trimmedCommand = command.trim();
-	if (trimmedCommand === "") {
-		return [];
-	}
-	const tokens = [];
-	for (const token of trimmedCommand.split(SPACES_REGEXP)) {
-		// Allow spaces to be escaped by a backslash if not meant as a delimiter
-		const previousToken = tokens.at(-1);
-		/* istanbul ignore next */
-		if (previousToken && previousToken.endsWith("\\")) {
-			// Merge previous token with current one
-			tokens[tokens.length - 1] = `${previousToken.slice(0, -1)} ${token}`;
-		} else {
-			tokens.push(token);
-		}
-	}
-	return tokens;
-};
+import { parseCommandString } from "./utilities.js";
 
 /**
  * Runs a shell command asynchronously and

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -1,5 +1,26 @@
-import { execaCommand } from "execa";
+import { execa, execaCommand } from "execa";
 import kleur from "kleur";
+
+const SPACES_REGEXP = / +/g;
+const parseCommandString = (command: string) => {
+	const trimmedCommand = command.trim();
+	if (trimmedCommand === "") {
+		return [];
+	}
+	const tokens = [];
+	for (const token of trimmedCommand.split(SPACES_REGEXP)) {
+		// Allow spaces to be escaped by a backslash if not meant as a delimiter
+		const previousToken = tokens.at(-1);
+		/* istanbul ignore next */
+		if (previousToken && previousToken.endsWith("\\")) {
+			// Merge previous token with current one
+			tokens[tokens.length - 1] = `${previousToken.slice(0, -1)} ${token}`;
+		} else {
+			tokens.push(token);
+		}
+	}
+	return tokens;
+};
 
 /**
  * Runs a shell command asynchronously and
@@ -16,33 +37,56 @@ export type RunResult = {
 	exitCode?: number;
 	shortMessage?: string;
 };
+export type RunOptions = {
+	ignoreError?: boolean;
+	streamOutput?: boolean;
+};
+type ExecaOptions = {
+	preferLocal: boolean;
+	shell: boolean;
+	stdout?: ["pipe", "inherit"];
+};
+
 export const run = async (
 	command: string,
-	options?: { ignoreError?: boolean },
+	options?: RunOptions,
 ): Promise<RunResult> => {
 	const { ignoreError } = {
 		ignoreError: false,
 		...options,
 	};
-	try {
-		const { stdout, stderr } = await execaCommand(command, {
-			/**
-			 * For some reason, a command with a " or ' in execa.command() will
-			 * fail, but it works if shell is set to true... It would work if
-			 * the execaCommand() API is not used:
-			 * execa("ls", ["-l", "|", "wc"]);
-			 * Same problems with &, &&, | and ||.
-			 */
-			shell:
-				command.includes('"') ||
-				command.includes("'") ||
-				command.includes("&&") ||
-				command.includes("&") ||
-				command.includes("||") ||
-				command.includes("|"),
-		});
+	const execaOptions: ExecaOptions = {
+		shell: false,
+		preferLocal: true,
+	};
 
-		return { stderr, stdout };
+	if (
+		command.includes("&&") ||
+		command.includes("&") ||
+		command.includes("||") ||
+		command.includes("|")
+	) {
+		execaOptions.shell = true;
+	}
+
+	/* istanbul ignore next */
+	if (options?.streamOutput) {
+		execaOptions.stdout = ["pipe", "inherit"];
+	}
+
+	try {
+		if (execaOptions.shell) {
+			const { stdout, stderr } = await execaCommand(command, execaOptions);
+			return { stderr, stdout };
+		} else {
+			const commandArray = parseCommandString(command);
+			const { stdout, stderr } = await execa(
+				commandArray[0],
+				commandArray.slice(1),
+				execaOptions,
+			);
+			return { stderr, stdout };
+		}
 	} catch (error) {
 		if (ignoreError) {
 			return {

--- a/packages/run/src/utilities.ts
+++ b/packages/run/src/utilities.ts
@@ -1,0 +1,21 @@
+const SPACES_REGEXP = / +/g;
+
+export const parseCommandString = (command: string) => {
+	const trimmedCommand = command.trim();
+	if (trimmedCommand === "") {
+		return [];
+	}
+	const tokens = [];
+	for (const token of trimmedCommand.split(SPACES_REGEXP)) {
+		// Allow spaces to be escaped by a backslash if not meant as a delimiter
+		const previousToken = tokens.at(-1);
+		/* istanbul ignore next */
+		if (previousToken && previousToken.endsWith("\\")) {
+			// Merge previous token with current one
+			tokens[tokens.length - 1] = `${previousToken.slice(0, -1)} ${token}`;
+		} else {
+			tokens.push(token);
+		}
+	}
+	return tokens;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new option `options.streamOutput` to enable streaming output behavior in the `run` function.
- **Documentation**
  - Updated `README.md` to include examples and explanations for the new `options.streamOutput` feature.
- **Tests**
  - Added new test cases to cover command failures and running commands with pipes or quotes.
- **Chores**
  - Enhanced testing capabilities with new scripts for echo test and watch mode in `package.json`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->