### PR TITLE
chore: add repository metadata to all packages for npm provenance

### DIFF
--- a/packages/bundlecheck/package.json
+++ b/packages/bundlecheck/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "CLI tool to check the bundle size of npm packages (like bundlephobia)",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/bundlecheck"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"main": "./dist/index.js",

--- a/packages/bundlesize/package.json
+++ b/packages/bundlesize/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "Simple CLI tool that checks file(s) size and report if limits have been reached",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/bundlesize"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/comments/package.json
+++ b/packages/comments/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "CLI tool to reflow and normalize JSDoc and line comments in source files",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/comments"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": "./dist/lib.js",

--- a/packages/envtools/package.json
+++ b/packages/envtools/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "Command line helper for software developers",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/envtools"
+	},
 	"files": [
 		"dist",
 		"README.md",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "A tiny console logger for nodejs CLI apps",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/logger"
+	},
 	"type": "module",
 	"exports": "./dist/Logger.js",
 	"files": [

--- a/packages/npmrc/package.json
+++ b/packages/npmrc/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "Toggle different npmrc configuration files on the fly",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/npmrc"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": "./dist/npmrc.js",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "A simple CLI parser helper",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/parser"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": "./dist/parser.js",

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "Set of performance tools for Node.js",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/perf"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": "./dist/performance.js",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "A wrapper for child_process for nodejs CLI apps",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/run"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": "./dist/run.js",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "Search for files in a directory",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/search"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": "./dist/core.js",

--- a/packages/secret/package.json
+++ b/packages/secret/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "Secret is a CLI tool that can encode or decode a file with a password",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/secret"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": "./dist/lib.js",

--- a/packages/static-server/package.json
+++ b/packages/static-server/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "A simple, zero-configuration, command line HTTP server to serve static files locally",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/static-server"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": "./dist/server.js",

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "Dead simpler CLI timer",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/timer"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": "./dist/timer.js",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -4,6 +4,11 @@
 	"license": "MIT",
 	"author": "Arno Versini",
 	"description": "A few utilities for Node CLI applications",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/versini-org/node-cli.git",
+		"directory": "packages/utilities"
+	},
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": "./dist/utilities.js",


### PR DESCRIPTION
## Summary

Adds a `repository` field to all 14 packages in the monorepo.

npm/sigstore provenance verification (used for OIDC publishing) requires `repository.url` to be present and to normalize to the source repository. A missing/empty URL produced:

> `Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/versini-org/node-cli"`

Each package now has:

```json
"repository": {
	"type": "git",
	"url": "git+https://github.com/versini-org/node-cli.git",
	"directory": "packages/<name>"
}
```

- `git+https` form normalizes cleanly to the provenance bundle URL (avoids the SSH/SCP normalization ambiguity).
- `directory` points each package at its subfolder so npm links to the correct path in the monorepo.

## Consumer impact

npm package pages will now link back to the source repository, and provenance-based publishing can validate successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)