### PR TITLE
chore(search): fix self-referential test count after repository metadata addition

### DIFF
--- a/packages/search/src/__tests__/core.test.ts
+++ b/packages/search/src/__tests__/core.test.ts
@@ -396,7 +396,7 @@ describe("when testing for utilities with logging side-effects", () => {
 
 		const search = new Search(config);
 		await search.start();
-		expect(mockLog).toHaveBeenCalledWith(" package.json (5 occurrences)");
+		expect(mockLog).toHaveBeenCalledWith(" package.json (6 occurrences)");
 	});
 
 	it("should exit in error if the grep pattern is invalid", async () => {


### PR DESCRIPTION
## Summary

Fixes the `search` test that broke after #564 added `repository` metadata to all packages.

`core.test.ts` runs the search tool against the search package's own `package.json`, grepping case-insensitively for `type`, and asserted **5 occurrences**. The new repository block introduced a `"type": "git"` line, bringing the real count to **6**. Updated the expectation to match.

## Verification

`pnpm test:coverage` for `@node-cli/search` now passes (100% statements/functions/lines).

> Note: a separate, pre-existing `bundlesize` gzip-size test failure is unrelated to this change and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)