### PR TITLE
fix(envtools): replace exit with return to allow tmux to work

### DIFF
--- a/packages/envtools/shell/load.sh
+++ b/packages/envtools/shell/load.sh
@@ -4,7 +4,7 @@
 # reload, get out of here quietly...
 if [ "$EVTLS_INIT_PARAM" != "reload" ] && [ "$EVTLS_RUNTIME_DIR" != "" ]; then
 	if [ "$VSCODE_CLI" = "" ] && [ "$VSC_TERMINAL" = "" ]; then
-		exit 0
+		return 0
 	fi
 fi
 


### PR DESCRIPTION
Replace exit 0 with return 0 to avoid terminating the parent shell when this script is sourced. The script is meant to be loaded (not executed) during environment setup, so returning ensures callers (e.g. interactive shells or editors) continue running while still skipping further initialization under the same conditions.