### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
 	"devDependencies": {
 		"@node-cli/comments": "workspace:*",
 		"@versini/dev-dependencies-common": "9.2.22",
-		"@versini/dev-dependencies-server": "9.0.9",
+		"@versini/dev-dependencies-server": "9.0.10",
 		"@versini/dev-dependencies-types": "4.1.15"
 	},
-	"packageManager": "pnpm@11.15.0"
+	"packageManager": "pnpm@11.15.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 9.2.22
         version: 9.2.22(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.1)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)
       '@versini/dev-dependencies-server':
-        specifier: 9.0.9
-        version: 9.0.9(chokidar@5.0.0)(postcss@8.5.16)(supports-color@5.5.0)(typescript@5.9.3)(yaml@2.9.0)
+        specifier: 9.0.10
+        version: 9.0.10(chokidar@5.0.0)(postcss@8.5.16)(supports-color@5.5.0)(typescript@5.9.3)(yaml@2.9.0)
       '@versini/dev-dependencies-types':
         specifier: 4.1.15
         version: 4.1.15
@@ -2060,8 +2060,8 @@ packages:
   '@versini/dev-dependencies-common@9.2.22':
     resolution: {integrity: sha512-p5381JFyYyPzRSuB7H4bDfPyMKOeeTzw9YS9eWb3AiPfSA/ew72yFJO9HDZaHZ37YV6QtZ7zrpiIhJK5ZNhUuQ==}
 
-  '@versini/dev-dependencies-server@9.0.9':
-    resolution: {integrity: sha512-XAXIamxEXoGwH1MtiLw69Z584zaG4keodPf/B2gL70R0SSGcl/ZGcvfLWbsOeBBwjgSkp8d6sGIT1Qb3D6DXrg==}
+  '@versini/dev-dependencies-server@9.0.10':
+    resolution: {integrity: sha512-U3onqkPcexrKwoLR+Pya1PQ3dI0+JMHTtFUYWqz6T9hkED3fcjFgYYGSdl+iKYtIXMaEDbAAUROVFhfFcY/S0A==}
 
   '@versini/dev-dependencies-types@4.1.15':
     resolution: {integrity: sha512-cJ8DvJG/WhvEmtfrr6SdpidvknDd9h+tNRhBxI7wLVcIMIhCTD4vY6dMpxcg8aoliVqX7XjWZ8BGJUKts1vN+g==}
@@ -4376,8 +4376,8 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
-  prettier@3.9.5:
-    resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6806,7 +6806,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@versini/dev-dependencies-server@9.0.9(chokidar@5.0.0)(postcss@8.5.16)(supports-color@5.5.0)(typescript@5.9.3)(yaml@2.9.0)':
+  '@versini/dev-dependencies-server@9.0.10(chokidar@5.0.0)(postcss@8.5.16)(supports-color@5.5.0)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
       '@swc/cli': 0.8.1(@swc/core@1.15.46(@swc/helpers@0.5.23))(chokidar@5.0.0)(supports-color@5.5.0)
       '@swc/core': 1.15.46(@swc/helpers@0.5.23)
@@ -6818,7 +6818,7 @@ snapshots:
       lint-staged: 17.1.0
       nodemon: 3.1.14
       npm-run-all2: 9.0.2
-      prettier: 3.9.5
+      prettier: 3.9.6
       rimraf: 6.1.3
       tsup: 8.5.1(@swc/core@1.15.46(@swc/helpers@0.5.23))(postcss@8.5.16)(supports-color@5.5.0)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
       tsx: 4.23.1
@@ -7862,6 +7862,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   figures@2.0.0:
     dependencies:
@@ -9011,7 +9015,7 @@ snapshots:
       ansi-styles: 6.2.3
       cross-spawn: 7.0.6
       memorystream: 0.3.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       pidtree: 1.0.0
       read-package-json-fast: 6.0.0
       shell-quote: 1.9.0
@@ -9494,7 +9498,7 @@ snapshots:
       tar-fs: 2.1.5
       tunnel-agent: 0.6.0
 
-  prettier@3.9.5: {}
+  prettier@3.9.6: {}
 
   pretty-format@30.4.1:
     dependencies:
@@ -10093,8 +10097,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyrainbow@3.1.0: {}
 
@@ -10253,7 +10257,7 @@ snapshots:
   vite@8.1.0(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       postcss: 8.5.16
       rolldown: 1.1.3
       tinyglobby: 0.2.17


### PR DESCRIPTION
Automated non-major dependency bump (deps-train).

**package.json**
- @versini/dev-dependencies-server → 9.0.10
- pnpm → 11.15.1
