### PR TITLE
feat!: upgrade execa to v10 and require Node 22

### DIFF
--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -16,9 +16,11 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=16",
+	"engines": {
+		"node": ">=22"
+	},
 	"dependencies": {
-		"execa": "9.6.1",
+		"execa": "10.0.0",
 		"kleur": "4.1.5"
 	},
 	"scripts": {

--- a/packages/run/src/run.ts
+++ b/packages/run/src/run.ts
@@ -1,4 +1,4 @@
-import { execa, execaCommand } from "execa";
+import { execa } from "execa";
 import kleur from "kleur";
 import { parseCommandString } from "./utilities.js";
 
@@ -57,7 +57,7 @@ export const run = async (
 
 	try {
 		if (execaOptions.shell) {
-			const { stdout, stderr } = await execaCommand(command, execaOptions);
+			const { stdout, stderr } = await execa(execaOptions)`${command}`;
 			return { stderr, stdout };
 		} else {
 			const commandArray = parseCommandString(command);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,8 +219,8 @@ importers:
   packages/run:
     dependencies:
       execa:
-        specifier: 9.6.1
-        version: 9.6.1
+        specifier: 10.0.0
+        version: 10.0.0
       kleur:
         specifier: 4.1.5
         version: 4.1.5
@@ -2899,6 +2899,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  execa@10.0.0:
+    resolution: {integrity: sha512-Cxl6MKxB1dr1H0FHmiizJ+lavKF7pV+fcDZFyqMB8d5m7qUPm/OtZYcD5vPWePKxSnTQ57KuBd9mtdZ3oNCvyQ==}
+    engines: {node: '>=22'}
+
   execa@5.0.0:
     resolution: {integrity: sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==}
     engines: {node: '>=10'}
@@ -5272,6 +5276,11 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  which-command@0.1.0:
+    resolution: {integrity: sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -7732,6 +7741,22 @@ snapshots:
       - bare-abort-controller
 
   events@3.3.0: {}
+
+  execa@10.0.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      path-key: 4.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      which-command: 0.1.0
+      yoctocolors: 2.1.2
 
   execa@5.0.0:
     dependencies:
@@ -10319,6 +10344,8 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  which-command@0.1.0: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
Upgrades `execa` in `@node-cli/run` from `9.6.1` to `10.0.0`.

## Breaking changes in execa 10 that touch this package

| Change | Affects `run`? |
| --- | --- |
| `execaCommand()` / `execaCommandSync()` removed | **Yes** |
| `engines.node` `^18.19.0 \|\| >=20.5.0` → `>=22` | **Yes** |
| Subprocess is no longer a `ChildProcess` (`.on()`, `.send()` move to `.nodeChildProcess`) | No |
| `stdio: [..., 'ipc']` → `ipc: true` | No |
| `input`/`inputFile` now take precedence over inherited stdin | No |

## The code change

```diff
-import { execa, execaCommand } from "execa";
+import { execa } from "execa";
@@
-const { stdout, stderr } = await execaCommand(command, execaOptions);
+const { stdout, stderr } = await execa(execaOptions)`${command}`;
```

The non-shell branch is untouched — it already used the local `parseCommandString` helper that execa's migration guide points to.

## The Node floor

`packages/run/package.json` declared a non-standard top-level `"node": ">=16"` field. npm and pnpm read `engines.node`, so that floor was never enforced. It is replaced with a real `"engines": { "node": ">=22" }` so execa 10's requirement is surfaced at install time rather than being silently transitive.

Node 20 reached EOL on 2026-04-30, so a Node 22 floor excludes only unsupported runtimes. CI already runs 24.x.

No downstream pin bumps needed — `search`, `npmrc`, and `examples/run` consume `run` via `workspace:*`.

## Verification

- `pnpm test` — 268 tests across 12 packages pass
- `pnpm lint` clean across 13 projects; `tsc` + swc build clean
- End-to-end, not just unit tests: `examples/run/run-example.js` output is byte-identical to execa 9, and the built `search` CLI exercised both `run` code paths (`id -nu` non-shell, `--command "wc -l"` shell)
- Error shapes unchanged — `shortMessage`, `exitCode`, and ENOENT handling match execa 9 for every existing assertion

## Follow-up (not in this PR)

The other 13 packages carry the same typo'd, non-enforced `"node"` field. Nothing reads it, but `search` and `npmrc` now transitively require Node 22 while declaring `>=18` / `>=16`. Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxPdHpfW5B4evcecAmHHqa