### PR TITLE
feat!: declare real engines.node across all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
 		"@versini/dev-dependencies-server": "9.0.11",
 		"@versini/dev-dependencies-types": "4.1.15"
 	},
-	"packageManager": "pnpm@11.15.1"
+	"packageManager": "pnpm@11.15.1",
+	"engines": {
+		"node": ">=22"
+	}
 }

--- a/packages/bundlecheck/package.json
+++ b/packages/bundlecheck/package.json
@@ -23,7 +23,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=20",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"build": "npm-run-all --serial clean build:types build:js",
 		"build:js": "swc --strip-leading-paths --source-maps --out-dir dist src",

--- a/packages/bundlesize/package.json
+++ b/packages/bundlesize/package.json
@@ -22,7 +22,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=18",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",

--- a/packages/comments/package.json
+++ b/packages/comments/package.json
@@ -17,7 +17,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=18",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",

--- a/packages/envtools/package.json
+++ b/packages/envtools/package.json
@@ -14,7 +14,9 @@
 		"README.md",
 		"shell"
 	],
-	"node": ">=18",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"build": "mkdir -p dist; echo \"export EVTLS_VERSION='$npm_package_version' \" > dist/version.sh",
 		"lint:fix": "biome check src --write --no-errors-on-unmatched"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -15,7 +15,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=16",
+	"engines": {
+		"node": ">=22"
+	},
 	"dependencies": {
 		"boxen": "8.0.1",
 		"kleur": "4.1.5",

--- a/packages/npmrc/package.json
+++ b/packages/npmrc/package.json
@@ -17,7 +17,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=18",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -16,7 +16,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=16",
+	"engines": {
+		"node": ">=22"
+	},
 	"dependencies": {
 		"@node-cli/logger": "workspace:*",
 		"@node-cli/utilities": "workspace:*",

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -16,7 +16,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=16",
+	"engines": {
+		"node": ">=22"
+	},
 	"dependencies": {
 		"@node-cli/logger": "workspace:*",
 		"@node-cli/utilities": "workspace:*"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -17,7 +17,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=16",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",

--- a/packages/secret/package.json
+++ b/packages/secret/package.json
@@ -17,7 +17,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=18",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",

--- a/packages/static-server/package.json
+++ b/packages/static-server/package.json
@@ -17,7 +17,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=18",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"build": "npm-run-all clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -17,7 +17,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=16",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"build": "npm-run-all --serial clean build:types build:js build:barrel",
 		"build:barrel": "barrelsby --delete --directory dist --pattern \"**/*.d.ts\" --name \"index.d\"",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -16,7 +16,9 @@
 		"dist",
 		"README.md"
 	],
-	"node": ">=16",
+	"engines": {
+		"node": ">=22"
+	},
 	"dependencies": {
 		"lodash-es": "4.18.1"
 	},


### PR DESCRIPTION
Follow-up to #601. Replaces the inert top-level `"node"` field with a real `engines.node` of `>=22` across all 14 packages.

## The bug

Every package declared a top-level `"node"` field — `">=16"`, `">=18"` or `">=20"` depending on the package. **npm and pnpm read `engines.node`, not that field.** None of these floors were ever enforced.

Proven by packing `@node-cli/logger` and installing it with `engine-strict=true` on Node 24:

| Manifest | Result |
| --- | --- |
| old `"node": ">=99"` | **installs silently** — the field is a no-op |
| new `"engines": { "node": ">=99" }` | **`EBADENGINE`**, hard fail |
| new `"engines": { "node": ">=22" }` | installs cleanly |

The declared values were also simply wrong. `@node-cli/logger` claimed `>=16` while depending on `ora@9`, which requires Node 20.

## What the dependency graph actually requires

| Real floor | Packages | Driven by |
| --- | --- | --- |
| ≥22 | `run`, `npmrc`, `search` | `execa@10`, directly or via `run` |
| ≥20 | `logger`, `parser`, `perf`, `comments`, `timer`, `bundlesize`, `static-server` | `ora`, `meow`, `glob`, `open` |
| ≥20.17 | `bundlecheck`, `secret` | `@inquirer/*`, `better-sqlite3` |
| unconstrained | `utilities`, `envtools` | `lodash-es` / no runtime deps |

## Why a uniform `>=22` rather than per-package floors

- **Node 20 reached EOL on 2026-04-30.** A `>=20` floor declares support for an unsupported runtime.
- **CI only tests 24.x.** Declaring a floor below what is tested is a claim not backed by evidence.
- **`@node-cli/run` already requires 22** via execa 10, and `search` and `npmrc` inherit it.
- **Per-package floors drift.** They are accurate only until the next dependency bump, and nothing verifies them. One rule cannot silently go stale.

The root manifest declares the same floor so contributor installs are gated too.

## Verification

- `pnpm install`, `pnpm build` (14 projects), `pnpm lint` (13 projects), `pnpm test` (12 projects) — all pass
- Enforcement verified end to end against a real packed tarball, per the table above

## Release impact

`feat!` with a `BREAKING CHANGE` footer — release-please will cut a major for each touched package. This is a genuine narrowing of the supported runtime contract: installs that were previously silent will now warn, or fail under `engine-strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxPdHpfW5B4evcecAmHHqa