### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/packages/static-server/package.json
+++ b/packages/static-server/package.json
@@ -35,7 +35,7 @@
 		"@fastify/caching": "9.0.3",
 		"@fastify/compress": "9.1.0",
 		"@fastify/cors": "11.3.0",
-		"@fastify/static": "10.1.0",
+		"@fastify/static": "10.1.2",
 		"@node-cli/logger": "workspace:*",
 		"@node-cli/parser": "workspace:*",
 		"fastify": "5.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,8 +306,8 @@ importers:
         specifier: 11.3.0
         version: 11.3.0
       '@fastify/static':
-        specifier: 10.1.0
-        version: 10.1.0
+        specifier: 10.1.2
+        version: 10.1.2
       '@node-cli/logger':
         specifier: workspace:*
         version: link:../logger
@@ -899,8 +899,8 @@ packages:
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
 
-  '@fastify/static@10.1.0':
-    resolution: {integrity: sha512-iK/8TvRM/EgNOyQL+EpWu+x3aR6o4GWt+UI+27zmE7w6t/6d80mXqOtWLdEKQ13vL/g1Jry0ae2icj6GP7tGzA==}
+  '@fastify/static@10.1.2':
+    resolution: {integrity: sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==}
 
   '@gar/promise-retry@1.0.3':
     resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
@@ -5764,7 +5764,7 @@ snapshots:
       http-errors: 2.0.1
       mime: 3.0.0
 
-  '@fastify/static@10.1.0':
+  '@fastify/static@10.1.2':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       '@fastify/error': 4.2.0


### PR DESCRIPTION
Automated non-major dependency bump (deps-train).

**packages/static-server/package.json**
- @fastify/static → 10.1.2
