### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@versini/dev-dependencies-server": "9.0.14",
 		"@versini/dev-dependencies-types": "4.1.15"
 	},
-	"packageManager": "pnpm@11.15.1",
+	"packageManager": "pnpm@11.16.0",
 	"engines": {
 		"node": ">=22"
 	}


### PR DESCRIPTION
Automated non-major dependency bump (deps-train).

**package.json**
- pnpm → 11.16.0
