### PR TITLE
build: bump dev-dependencies-common to 11.0.0 (npm-check-updates 23)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	},
 	"devDependencies": {
 		"@node-cli/comments": "workspace:*",
-		"@versini/dev-dependencies-common": "10.0.1",
+		"@versini/dev-dependencies-common": "11.0.0",
 		"@versini/dev-dependencies-server": "9.0.15",
 		"@versini/dev-dependencies-types": "4.1.16"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: workspace:*
         version: link:packages/comments
       '@versini/dev-dependencies-common':
-        specifier: 10.0.1
-        version: 10.0.1(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.2)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)
+        specifier: 11.0.0
+        version: 11.0.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.2)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)
       '@versini/dev-dependencies-server':
         specifier: 9.0.15
         version: 9.0.15(chokidar@5.0.0)(postcss@8.5.16)(supports-color@5.5.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -2057,8 +2057,8 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@versini/dev-dependencies-common@10.0.1':
-    resolution: {integrity: sha512-5gZhG2Q6pgZp5TD1mzqbMNqrrCNXmPlDOZQgm66TwKJSW3jyD1Ggvn6aS6v22bSGXmpVIhjaeBJJJjwoAaXBbg==}
+  '@versini/dev-dependencies-common@11.0.0':
+    resolution: {integrity: sha512-AhXdlpxzARxYBPcYJokd+01hU3ZBXE/Xr1eq+YBY6w9JauHBNNAU16oxkQZXIT09tRnBgKarkgGncbYq8EeuuA==}
 
   '@versini/dev-dependencies-server@9.0.15':
     resolution: {integrity: sha512-UHkv6nYN1BvwmHEWp/wk1PGc2QntJRrELwRnwp146wccUjZU1U1fMM5/7V3jjC6xb4DMB18YMgwMscmQGKN9gQ==}
@@ -3051,10 +3051,6 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
-  fs-extra@11.3.6:
-    resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
-    engines: {node: '>=14.14'}
-
   fs-extra@11.4.0:
     resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
     engines: {node: '>=14.14'}
@@ -3978,9 +3974,9 @@ packages:
     resolution: {integrity: sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  npm-check-updates@22.2.9:
-    resolution: {integrity: sha512-DVeZ0KirHfliSsHuR2o7cHE+tW439sVHfJjF6cGWeDiY0Wyl3BI/jS4zV0eixtcMOquFbcF1Su/FsxOvk5MoYA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: '>=10.0.0'}
+  npm-check-updates@23.0.0:
+    resolution: {integrity: sha512-B7dvnnS4Tm/4YQghXjBgGBDuHsk88hqCmr4ZuCr0nscsPzf/QVMls5mT8ZUcHrcrFRBP1afB2KNuJo8Px55DrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0, npm: '>=10.0.0'}
     hasBin: true
 
   npm-install-checks@7.1.2:
@@ -6634,7 +6630,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/bytes@3.1.5': {}
 
@@ -6645,7 +6641,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/culori@4.0.1': {}
 
@@ -6655,7 +6651,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -6677,7 +6673,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/lodash-es@4.17.12':
     dependencies:
@@ -6719,18 +6715,18 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -6738,7 +6734,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@versini/dev-dependencies-common@10.0.1(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.2)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)':
+  '@versini/dev-dependencies-common@11.0.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.2)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)':
     dependencies:
       '@biomejs/biome': 2.5.6
       chokidar: 5.0.0
@@ -6749,7 +6745,7 @@ snapshots:
       happy-dom: 20.11.1
       jsdom: 29.1.1
       lerna: 9.0.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.2)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)
-      npm-check-updates: 22.2.9
+      npm-check-updates: 23.0.0
       typescript: 6.0.3
       uuid: 14.0.1
     transitivePeerDependencies:
@@ -7156,7 +7152,7 @@ snapshots:
 
   buffer-image-size@0.6.4:
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   buffer@5.7.1:
     dependencies:
@@ -7902,12 +7898,6 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
-  fs-extra@11.3.6:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.1
-      universalify: 2.0.1
-
   fs-extra@11.4.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -8047,7 +8037,7 @@ snapshots:
 
   happy-dom@20.11.1:
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       buffer-image-size: 0.6.4
@@ -8428,7 +8418,7 @@ snapshots:
       dedent: 1.5.3
       envinfo: 7.13.0
       execa: 5.0.0
-      fs-extra: 11.3.6
+      fs-extra: 11.4.0
       get-stream: 6.0.0
       git-url-parse: 14.0.0
       glob-parent: 6.0.2
@@ -8897,7 +8887,7 @@ snapshots:
     dependencies:
       npm-normalize-package-bin: 5.0.0
 
-  npm-check-updates@22.2.9: {}
+  npm-check-updates@23.0.0: {}
 
   npm-install-checks@7.1.2:
     dependencies:


### PR DESCRIPTION
Bumps `@versini/dev-dependencies-common` 10.0.1 → 11.0.0.

## What actually changed

The **only** difference between common 10.0.1 and 11.0.0 is `npm-check-updates` 22.2.9 → 23.0.0. The biome / tsconfig / vitest presets are byte-identical between the two releases, so nothing about this repo's lint, build, or test behavior moves.

common went **major** because ncu is one of its runtime `dependencies` (not a devDependency), so v23's Node floor — `^22.22.2 || ^24.15.0 || >=26.0.0` — propagates here on install. CI runs Node 22.x, which resolves to v22.23.1 and clears it.

## Why v23 isn't disruptive

Its four breaking changes were checked against this ecosystem's actual usage:

1. **Pure ESM, no CommonJS build.** `.ncurc.cjs` opens with `require("npm-check-updates")` for `defineConfig`; that still resolves via Node's `require(esm)` path, since the v23 entry has no top-level await.
2. **`filterVersion`/`rejectVersion` lost predicate-function support.** No `.ncurc.cjs` in any repo uses either. The three function-valued options in use — `filterResults`, `cooldown`, `target` — have identical signatures in v22 and v23.
3. **`--format` now defaults to grouped output.** Cosmetic; upgrades are grouped by major/minor/patch.
4. **`--target semver` respects upper bounds.** No config uses `target: 'semver'`.

## Verification

`pnpm lint`, `pnpm test` (plus `pnpm typecheck` where the repo has one) all pass locally against the new pin, and `ncu` resolves to 23.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6DpUPA4ofQeXDyLbhPzdW