### PR TITLE
build: bump dev-dependencies-common to 12.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	},
 	"devDependencies": {
 		"@node-cli/comments": "workspace:*",
-		"@versini/dev-dependencies-common": "11.0.0",
+		"@versini/dev-dependencies-common": "12.0.0",
 		"@versini/dev-dependencies-server": "9.0.15",
 		"@versini/dev-dependencies-types": "4.1.16"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: workspace:*
         version: link:packages/comments
       '@versini/dev-dependencies-common':
-        specifier: 11.0.0
-        version: 11.0.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.2)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)
+        specifier: 12.0.0
+        version: 12.0.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.2)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)
       '@versini/dev-dependencies-server':
         specifier: 9.0.15
         version: 9.0.15(chokidar@5.0.0)(postcss@8.5.16)(supports-color@5.5.0)(typescript@5.9.3)(yaml@2.9.0)
@@ -2057,8 +2057,8 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@versini/dev-dependencies-common@11.0.0':
-    resolution: {integrity: sha512-AhXdlpxzARxYBPcYJokd+01hU3ZBXE/Xr1eq+YBY6w9JauHBNNAU16oxkQZXIT09tRnBgKarkgGncbYq8EeuuA==}
+  '@versini/dev-dependencies-common@12.0.0':
+    resolution: {integrity: sha512-ktxmFaCQkw/+fUL/ASy1xTp9yrNi2fhDJ4a9c+nJbLmwU61K42s8X5dlzTN6f4UEzMxt1iCYVj5RO2MakE1NKA==}
 
   '@versini/dev-dependencies-server@9.0.15':
     resolution: {integrity: sha512-UHkv6nYN1BvwmHEWp/wk1PGc2QntJRrELwRnwp146wccUjZU1U1fMM5/7V3jjC6xb4DMB18YMgwMscmQGKN9gQ==}
@@ -2676,10 +2676,6 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  culori@4.0.2:
-    resolution: {integrity: sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   dargs@7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
     engines: {node: '>=8'}
@@ -2774,10 +2770,6 @@ packages:
 
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
-    engines: {node: '>=12'}
-
-  dotenv@17.4.2:
-    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -5369,6 +5361,7 @@ snapshots:
       '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@asamuzakjp/dom-selector@7.1.1':
     dependencies:
@@ -5377,10 +5370,13 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
+    optional: true
 
-  '@asamuzakjp/generational-cache@1.0.1': {}
+  '@asamuzakjp/generational-cache@1.0.1':
+    optional: true
 
-  '@asamuzakjp/nwsapi@2.3.9': {}
+  '@asamuzakjp/nwsapi@2.3.9':
+    optional: true
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -5443,16 +5439,19 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+    optional: true
 
   '@colors/colors@1.5.0':
     optional: true
 
-  '@csstools/color-helpers@6.1.0': {}
+  '@csstools/color-helpers@6.1.0':
+    optional: true
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -5460,16 +5459,20 @@ snapshots:
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
+    optional: true
 
-  '@csstools/css-tokenizer@4.0.0': {}
+  '@csstools/css-tokenizer@4.0.0':
+    optional: true
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -5655,7 +5658,8 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@exodus/bytes@1.15.1': {}
+  '@exodus/bytes@1.15.1':
+    optional: true
 
   '@fastify/accept-negotiator@2.0.1': {}
 
@@ -6734,28 +6738,21 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@versini/dev-dependencies-common@11.0.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.2)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)':
+  '@versini/dev-dependencies-common@12.0.0(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.2)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)':
     dependencies:
       '@biomejs/biome': 2.5.6
-      chokidar: 5.0.0
-      culori: 4.0.2
-      dotenv: 17.4.2
       fs-extra: 11.4.0
-      glob: 13.0.6
       happy-dom: 20.11.1
-      jsdom: 29.1.1
       lerna: 9.0.7(@swc/core@1.15.46(@swc/helpers@0.5.23))(@types/node@26.1.2)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)
       npm-check-updates: 23.0.0
       typescript: 6.0.3
       uuid: 14.0.1
     transitivePeerDependencies:
-      - '@noble/hashes'
       - '@swc-node/register'
       - '@swc/core'
       - '@types/node'
       - babel-plugin-macros
       - bufferutil
-      - canvas
       - debug
       - supports-color
       - utf-8-validate
@@ -7088,6 +7085,7 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+    optional: true
 
   bin-links@5.0.0:
     dependencies:
@@ -7264,6 +7262,7 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+    optional: true
 
   chownr@3.0.0: {}
 
@@ -7454,12 +7453,11 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+    optional: true
 
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
-
-  culori@4.0.2: {}
 
   dargs@7.0.0: {}
 
@@ -7469,6 +7467,7 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   dateformat@3.0.3: {}
 
@@ -7493,7 +7492,8 @@ snapshots:
 
   decamelize@1.2.0: {}
 
-  decimal.js@10.6.0: {}
+  decimal.js@10.6.0:
+    optional: true
 
   decompress-response@10.0.0:
     dependencies:
@@ -7536,8 +7536,6 @@ snapshots:
 
   dotenv@16.4.7: {}
 
-  dotenv@17.4.2: {}
-
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -7565,7 +7563,8 @@ snapshots:
 
   entities@7.0.1: {}
 
-  entities@8.0.0: {}
+  entities@8.0.0:
+    optional: true
 
   env-paths@2.2.1: {}
 
@@ -8087,6 +8086,7 @@ snapshots:
       '@exodus/bytes': 1.15.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   html-escaper@2.0.2: {}
 
@@ -8255,7 +8255,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-potential-custom-element-name@1.0.1: {}
+  is-potential-custom-element-name@1.0.1:
+    optional: true
 
   is-ssh@1.4.1:
     dependencies:
@@ -8350,6 +8351,7 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   json-parse-better-errors@1.0.2: {}
 
@@ -8670,7 +8672,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdn-data@2.27.1: {}
+  mdn-data@2.27.1:
+    optional: true
 
   memorystream@0.3.1: {}
 
@@ -9295,6 +9298,7 @@ snapshots:
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
+    optional: true
 
   path-exists@3.0.0: {}
 
@@ -9473,7 +9477,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  punycode@2.3.1: {}
+  punycode@2.3.1:
+    optional: true
 
   quick-format-unescaped@4.0.4: {}
 
@@ -9554,7 +9559,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
-  readdirp@5.0.0: {}
+  readdirp@5.0.0:
+    optional: true
 
   real-require@0.2.0: {}
 
@@ -9690,6 +9696,7 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+    optional: true
 
   secure-json-parse@4.1.0: {}
 
@@ -9924,7 +9931,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  symbol-tree@3.2.4: {}
+  symbol-tree@3.2.4:
+    optional: true
 
   system-architecture@1.0.0: {}
 
@@ -10002,11 +10010,13 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.4.5: {}
+  tldts-core@7.4.5:
+    optional: true
 
   tldts@7.4.5:
     dependencies:
       tldts-core: 7.4.5
+    optional: true
 
   tmp@0.2.7: {}
 
@@ -10029,10 +10039,12 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.4.5
+    optional: true
 
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -10129,7 +10141,8 @@ snapshots:
 
   undici@6.27.0: {}
 
-  undici@7.28.0: {}
+  undici@7.28.0:
+    optional: true
 
   unicorn-magic@0.3.0: {}
 
@@ -10199,6 +10212,7 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+    optional: true
 
   walk-up-path@4.0.0: {}
 
@@ -10208,11 +10222,13 @@ snapshots:
 
   web-worker@1.5.0: {}
 
-  webidl-conversions@8.0.1: {}
+  webidl-conversions@8.0.1:
+    optional: true
 
   whatwg-mimetype@3.0.0: {}
 
-  whatwg-mimetype@5.0.0: {}
+  whatwg-mimetype@5.0.0:
+    optional: true
 
   whatwg-url@16.0.1:
     dependencies:
@@ -10221,6 +10237,7 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   which-command@0.1.0: {}
 
@@ -10292,9 +10309,11 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  xml-name-validator@5.0.0: {}
+  xml-name-validator@5.0.0:
+    optional: true
 
-  xmlchars@2.2.0: {}
+  xmlchars@2.2.0:
+    optional: true
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
Bumps `@versini/dev-dependencies-common` 11.0.0 → 12.0.0.

## What v12 changes

It drops five dependencies from the preset bundle — `chokidar`, `culori`, `dotenv`, `glob`, `jsdom` — after an audit across all eight repos (versini-org/dev-dependencies#870) found nothing relies on this package to supply them:

| dep | finding |
| --- | --- |
| `chokidar` | no reference of any kind, anywhere |
| `culori` | 1 import site, in `ui-styles`, which declares it |
| `dotenv` | 39 import sites, every one in a package that declares it |
| `glob` | 1 import site, in `node-cli/bundlesize`, which declares it |
| `jsdom` | 3 import sites, all in `sassysaint/tools`, which declares it |

The seven that remain are the ones consumers genuinely lean on without declaring: the `biome` / `tsc` / `lerna` binaries, `npm-check-updates` (every `.ncurc.cjs` imports it), `happy-dom` (the vitest environment in 10 configs), plus `fs-extra` and `uuid`.

## Verification

Verified in this repo rather than only in the producer — `lint`, `test`, `build`, and `typecheck` where applicable, all green against the trimmed bundle. Nothing here was resolving one of the removed packages through the preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6DpUPA4ofQeXDyLbhPzdW