### PR TITLE
build: drop empty `overrides:` key from pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,6 @@ packages:
   - packages/*
   - examples/*
 
-overrides:
-
 strictDepBuilds: true
 minimumReleaseAge: 420 # 7 hours in minutes
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## Why

`pnpm install` crashes under **pnpm 11.18.0** whenever a dependency specifier changes:

```
[ERROR] Cannot convert undefined or null to object
    at Object.values (<anonymous>)
    at _install (pnpm.mjs:193087:43)
```

11.18.0 added a fast-path lockfile update that calls `Object.values()` on the workspace `overrides` with no null guard. Our `pnpm-workspace.yaml` has an `overrides:` key with nothing under it, which YAML parses as `null` — that beats pnpm's `{}` default and throws. The code does not exist in 11.17.0, so this is a 11.18.0 regression.

The fast path only runs when specifiers changed, which is why a plain `pnpm install` never showed it — but a dependency bump always triggers it. This took down the deps-train on `ui-icons` today; `node-cli` is the same shape and would fail the same way the moment it moves to 11.18.0.

## What

Delete the empty `overrides:` key. It held no entries, so this is a no-op for resolution — `pnpm install --lockfile-only` afterwards leaves `pnpm-lock.yaml` byte-identical.

Verified by reproducing on 11.18.0 with the key present (crashes, same line) and absent (installs clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm4oPDceHFw3DN6MQG8wbz