### PR TITLE
build: gate ncu at 7h, not 24h, to match minimumReleaseAge

### DIFF
--- a/.ncurc.cjs
+++ b/.ncurc.cjs
@@ -6,7 +6,7 @@ const { defineConfig } = require("npm-check-updates");
  *
  * This configuration file is used by the `ncu` command to check for package updates.
  * It enables interactive mode, workspace support, and root package updates for
- * major and minor versions that have been released at least 1 day ago.
+ * major and minor versions that have been released at least 7 hours ago.
  *
  */
 module.exports = defineConfig({
@@ -27,15 +27,17 @@ module.exports = defineConfig({
 	},
 
 	/**
-	 * Set cooldown to 1 day but skip it for our packages.
+	 * Mirror pnpm-workspace.yaml's `minimumReleaseAge: 420` (7 hours), skipping it
+	 * for our own packages. Keep this a duration STRING: ncu reads a bare number
+	 * as days, so `1` here would silently gate at 24h instead of 7h.
 	 * @param packageName     The name of the dependency.
-	 * @returns               Cooldown days restriction for given package.
+	 * @returns               Cooldown restriction for given package.
 	 */
 	cooldown: (packageName) => {
 		return packageName.startsWith("@versini") ||
 			packageName.startsWith("@node-cli") ||
 			packageName.startsWith("@sassysaint")
 			? 0
-			: 1;
+			: "7h";
 	},
 });


### PR DESCRIPTION
## Why

`.ncurc.cjs` returned the bare number `1` for `cooldown`. **ncu reads a bare number as days**, so this repo has been asking for a 24h supply-chain delay while:

- its own `pnpm-workspace.yaml` asks for 7h (`minimumReleaseAge: 420`), and
- all seven other repos in the fleet return the string `"7h"`.

It fails as a silent no-op, not an error. Anything published 7–24h ago is invisible here but visible everywhere else, so the deps-train reports `no non-major updates` for `node-cli` while bumping the same package in the repo next door. That's how this surfaced: `ui-icons` offered `pnpm→11.18.0` and `node-cli` claimed nothing was available, despite sitting on 11.17.0.

Two updates were being hidden right now:

| package | version | age |
| --- | --- | --- |
| `pnpm` | 11.18.0 | 15.0h |
| `better-sqlite3` | 13.0.2 | 19.8h |

Both clear 7h, neither clears 24h.

## What

`1` → `"7h"`, and the comment now says what the value is for and why it must stay a duration string.

Likely a missed migration: the other seven repos moved from `1` to `"7h"` but kept the old *"Set cooldown to 1 day"* / *"@returns Cooldown days restriction"* prose, which is still in their configs today. `node-cli` kept the old value as well as the old prose.

## Verification

- Audited all eight repos across **495 dependency names** (every declared dep plus synthetic probes, since `cooldown` is a function of the package name and could special-case a subset). Every cooldown now resolves to 0h for in-house scopes or 7h for third-party. `node-cli` was the only outlier, and no repo has a stray `.ncurc` in another format.
- `deps-train --only node-cli` (dry-run) now reports exactly `pnpm→11.18.0, better-sqlite3→13.0.2`, matching an independent read-only ncu sweep at both gates.

ncu-only config: no lockfile or dependency change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pm4oPDceHFw3DN6MQG8wbz