### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	},
 	"devDependencies": {
 		"@node-cli/comments": "workspace:*",
-		"@versini/dev-dependencies-common": "13.0.2",
+		"@versini/dev-dependencies-common": "13.0.3",
 		"barrelsby": "2.8.1"
 	},
 	"packageManager": "pnpm@11.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: workspace:*
         version: link:packages/comments
       '@versini/dev-dependencies-common':
-        specifier: 13.0.2
-        version: 13.0.2(chokidar@5.0.0)(debug@4.4.3(supports-color@7.2.0))(happy-dom@20.11.1)(jsdom@29.1.1)(supports-color@7.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: 13.0.3
+        version: 13.0.3(chokidar@5.0.0)(debug@4.4.3(supports-color@7.2.0))(happy-dom@20.11.1)(jsdom@29.1.1)(supports-color@7.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
       barrelsby:
         specifier: 2.8.1
         version: 2.8.1
@@ -1746,8 +1746,8 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@versini/dev-dependencies-common@13.0.2':
-    resolution: {integrity: sha512-pGcp5XbKgYHnfAxRL5Sp8CInvs0XRqx/pqweSpLcvWjTqX/cFsETLvZG1vCUx2sPmdM7cDz6qm2LHnttECnsmQ==}
+  '@versini/dev-dependencies-common@13.0.3':
+    resolution: {integrity: sha512-ELynkIzk5NN+LHq5p4BtU8OIyC+B8xjlxsSRvXclVKvD4OnWKBY3TC9MJTKnJgK8IlmC7tJ3n4YYCIkBeOlAVQ==}
 
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
@@ -3284,8 +3284,8 @@ packages:
     resolution: {integrity: sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  lint-staged@17.2.0:
-    resolution: {integrity: sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A==}
+  lint-staged@17.3.0:
+    resolution: {integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==}
     engines: {node: '>=22.22.1'}
     hasBin: true
 
@@ -6066,7 +6066,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@versini/dev-dependencies-common@13.0.2(chokidar@5.0.0)(debug@4.4.3(supports-color@7.2.0))(happy-dom@20.11.1)(jsdom@29.1.1)(supports-color@7.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))':
+  '@versini/dev-dependencies-common@13.0.3(chokidar@5.0.0)(debug@4.4.3(supports-color@7.2.0))(happy-dom@20.11.1)(jsdom@29.1.1)(supports-color@7.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@biomejs/biome': 2.5.6
       '@swc/cli': 0.8.1(@swc/core@1.15.47(@swc/helpers@0.5.23))(chokidar@5.0.0)(supports-color@7.2.0)
@@ -6085,7 +6085,7 @@ snapshots:
       fs-extra: 11.4.0
       husky: 9.1.7
       lerna: 9.0.7(@swc/core@1.15.47(@swc/helpers@0.5.23))(@types/node@26.1.2)(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
-      lint-staged: 17.2.0
+      lint-staged: 17.3.0
       npm-check-updates: 23.0.0
       npm-run-all2: 9.0.3
       rimraf: 6.1.3
@@ -7778,7 +7778,7 @@ snapshots:
 
   lines-and-columns@2.0.3: {}
 
-  lint-staged@17.2.0:
+  lint-staged@17.3.0:
     dependencies:
       picomatch: 4.0.5
       string-argv: 0.3.2


### PR DESCRIPTION
Automated non-major dependency bump (deps-train).

**package.json**
- @versini/dev-dependencies-common → 13.0.3
