### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	},
 	"devDependencies": {
 		"@node-cli/comments": "workspace:*",
-		"@versini/dev-dependencies-common": "14.0.0",
+		"@versini/dev-dependencies-common": "14.0.1",
 		"barrelsby": "2.8.1",
 		"lerna": "10.0.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: workspace:*
         version: link:packages/comments
       '@versini/dev-dependencies-common':
-        specifier: 14.0.0
-        version: 14.0.0(chokidar@5.0.0)(happy-dom@20.11.1)(jsdom@29.1.1)(supports-color@7.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: 14.0.1
+        version: 14.0.1(chokidar@5.0.0)(happy-dom@20.11.1)(jsdom@29.1.1)(supports-color@7.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))
       barrelsby:
         specifier: 2.8.1
         version: 2.8.1
@@ -1756,8 +1756,8 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@versini/dev-dependencies-common@14.0.0':
-    resolution: {integrity: sha512-tHGqpyytDLKs46Z72Uf6buHboMdnHpXICKz8iAEEDBJVKBg402nqSgO046kgIGvhtCZ1gA5fmmSMsJ6q8Cr7ow==}
+  '@versini/dev-dependencies-common@14.0.1':
+    resolution: {integrity: sha512-btWM3X5WGn2JyVvtabcHcrZqh43JlzM7bGS5y6HheB3gMkOpwI/k/njouahO3DDtGj5QlXu9joagohuSeovfPQ==}
 
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
@@ -3403,8 +3403,8 @@ packages:
     resolution: {integrity: sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  npm-check-updates@23.0.0:
-    resolution: {integrity: sha512-B7dvnnS4Tm/4YQghXjBgGBDuHsk88hqCmr4ZuCr0nscsPzf/QVMls5mT8ZUcHrcrFRBP1afB2KNuJo8Px55DrA==}
+  npm-check-updates@23.0.1:
+    resolution: {integrity: sha512-e4hu3Rq4waj7SnhzvqAc5UG557mfP5e3JIFFQd7Fg3RiRkJl8yR90NFoZ1GSWUT3S/QacJndJb+7dLQBPeH+iA==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0, npm: '>=10.0.0'}
     hasBin: true
 
@@ -5780,7 +5780,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@versini/dev-dependencies-common@14.0.0(chokidar@5.0.0)(happy-dom@20.11.1)(jsdom@29.1.1)(supports-color@7.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))':
+  '@versini/dev-dependencies-common@14.0.1(chokidar@5.0.0)(happy-dom@20.11.1)(jsdom@29.1.1)(supports-color@7.2.0)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@biomejs/biome': 2.5.6
       '@swc/cli': 0.8.1(@swc/core@1.15.47(@swc/helpers@0.5.23))(chokidar@5.0.0)(supports-color@7.2.0)
@@ -5799,7 +5799,7 @@ snapshots:
       fs-extra: 11.4.0
       husky: 9.1.7
       lint-staged: 17.3.0
-      npm-check-updates: 23.0.0
+      npm-check-updates: 23.0.1
       npm-run-all2: 9.0.3
       rimraf: 6.1.3
       typescript: 6.0.3
@@ -7608,7 +7608,7 @@ snapshots:
     dependencies:
       npm-normalize-package-bin: 5.0.0
 
-  npm-check-updates@23.0.0: {}
+  npm-check-updates@23.0.1: {}
 
   npm-install-checks@7.1.2:
     dependencies:


### PR DESCRIPTION
Automated non-major dependency bump (deps-train).

**package.json**
- @versini/dev-dependencies-common 14.0.0 → 14.0.1

---

### What changed

<details>
<summary><code>@versini/dev-dependencies-common</code> 14.0.0 → 14.0.1</summary>

#### [dev-dependencies-common: v14.0.1](https://github.com/versini-org/dev-dependencies/releases/tag/dev-dependencies-common-v14.0.1)

## [14.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v14.0.0...dev-dependencies-common-v14.0.1) (2026-08-03)


### Bug Fixes

* bump non-breaking dependencies to latest ([#885](https://github.com/versini-org/dev-dependencies/issues/885)) ([eaf3a15](https://github.com/versini-org/dev-dependencies/commit/eaf3a150d8c21d6b3b8583760eceedf632c3c6e7))

[compare 14.0.0…14.0.1](https://github.com/versini-org/dev-dependencies/compare/dev-dependencies-common-v14.0.0...dev-dependencies-common-v14.0.1) · [npm](https://www.npmjs.com/package/@versini/dev-dependencies-common/v/14.0.1)
</details>
