### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"barrelsby": "2.8.1",
 		"lerna": "10.0.0"
 	},
-	"packageManager": "pnpm@11.19.0",
+	"packageManager": "pnpm@11.20.0",
 	"engines": {
 		"node": ">=22"
 	}

--- a/packages/static-server/package.json
+++ b/packages/static-server/package.json
@@ -38,7 +38,7 @@
 		"@fastify/static": "10.1.2",
 		"@node-cli/logger": "workspace:*",
 		"@node-cli/parser": "workspace:*",
-		"fastify": "5.11.0",
+		"fastify": "5.11.2",
 		"fastify-plugin": "6.0.0",
 		"fs-extra": "11.4.0",
 		"kleur": "4.1.5",

--- a/packages/static-server/src/server.ts
+++ b/packages/static-server/src/server.ts
@@ -6,7 +6,7 @@ import fastifyCompress from "@fastify/compress";
 import fastifyCors from "@fastify/cors";
 import fastifyStatic, { FastifyStaticOptions } from "@fastify/static";
 import { Logger } from "@node-cli/logger";
-import Fastify from "fastify";
+import Fastify, { FastifyServerOptions } from "fastify";
 import fs from "fs-extra";
 import kleur from "kleur";
 import open from "open";
@@ -28,11 +28,9 @@ if (fs.pathExistsSync(customPath)) {
 	logger.printErrorsAndExit([`Folder ${customPath} does not exist!`], 0);
 }
 
-const fastifyOptions: {
-	disableRequestLogging?: boolean;
+const fastifyOptions: FastifyServerOptions & {
 	http2?: boolean;
 	https?: any;
-	logger?: any;
 } = {
 	disableRequestLogging: true,
 };
@@ -56,7 +54,13 @@ if (config.flags.http2) {
 	fastifyOptions.https = { key, cert };
 }
 
-const fastify = Fastify(fastifyOptions);
+/*
+ * fastify@5.11.2 narrowed its HTTP overloads with `http2?: false`, so an
+ * options object carrying a `boolean` http2 no longer matches any of them.
+ * Build the server through the plain HTTP signature - as it has always
+ * resolved - and let the http2/https options through at runtime.
+ */
+const fastify = Fastify(fastifyOptions as FastifyServerOptions);
 
 if (config.flags.logs) {
 	fastify.register(fastifyLogs);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,8 +315,8 @@ importers:
         specifier: workspace:*
         version: link:../parser
       fastify:
-        specifier: 5.11.0
-        version: 5.11.0
+        specifier: 5.11.2
+        version: 5.11.2
       fastify-plugin:
         specifier: 6.0.0
         version: 6.0.0
@@ -2523,8 +2523,8 @@ packages:
   fastify-plugin@6.0.0:
     resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
 
-  fastify@5.11.0:
-    resolution: {integrity: sha512-Y/Ecx1yt0hYzrQR+QVLbxaUN8wCX+MQzMevh29r5RRvlOIArmi4+WAXXaGl5Hw5gBr2wduZpZaT3gRCnXoyVgA==}
+  fastify@5.11.2:
+    resolution: {integrity: sha512-i/eJG7nXR9OkbFgoX4jFiPOHoRq0rXqDACVAXELh5Fdg6BFBErIVZ8MyibGCwup9Go1pYrxZJ0ogIub8vVdEcQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6667,7 +6667,7 @@ snapshots:
 
   fastify-plugin@6.0.0: {}
 
-  fastify@5.11.0:
+  fastify@5.11.2:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0


### PR DESCRIPTION
Automated non-major dependency bump (deps-train).

**package.json**
- pnpm 11.19.0 → 11.20.0

**packages/static-server/package.json**
- fastify 5.11.0 → 5.11.2

---

### What changed

<details>
<summary><code>pnpm</code> 11.19.0 → 11.20.0</summary>

#### [pnpm 11.20](https://github.com/pnpm/pnpm/releases/tag/v11.20.0)

## Minor Changes

* **Security fix.** Affects projects using `namedRegistries` on pnpm 11.1.0–11.19.x. It is **semi-breaking** for those projects — see "If you use named registries" below.

  The lockfile recorded no marker for which registry a package came from. Packages were keyed by `name@version` alone, and entry lookup went through `refToRelative(ref, name)`, so a dependency you declared against one registry could be satisfied by an entry that was actually resolved from another. When two registries served the same name and version, both collapsed onto a single `packages:` entry and whichever resolved first decided the tarball every consumer got.

  That is a package-substitution risk: a package you expect from your private registry could be installed from a different registry that publishes the same name and version, and the lockfile recorded nothing that would let you tell.

  Packages resolved from a named registry are now recorded under registry-qualified keys (`<name>@<registryName>:<version>`, e.g. `foo@work:1.0.0`), so each registry gets its own entry and the lockfile pins which one a dependency came from.

  The lockfile format version is unchanged. Registry-qualified keys appear only for packages resolved from a named registry, so a project that does not use `namedRegistries` sees no difference, and older pnpm versions keep reading the file.

  ### If you use named registries

  Your next non-frozen install re-keys those entries, which shows up as a

_…notes truncated._

[compare 11.19.0…11.20.0](https://github.com/pnpm/pnpm/compare/v11.19.0...v11.20.0) · [npm](https://www.npmjs.com/package/pnpm/v/11.20.0)
</details>

<details>
<summary><code>fastify</code> 5.11.0 → 5.11.2</summary>

#### [v5.11.2](https://github.com/fastify/fastify/releases/tag/v5.11.2)

**Full Changelog**: https://github.com/fastify/fastify/compare/v5.11.1...v5.11.2

#### [v5.11.1](https://github.com/fastify/fastify/releases/tag/v5.11.1)

## What's Changed
* fix: add http method override warning by `@jean-michelet` in https://github.com/fastify/fastify/pull/6879
* fix(types): allow explicit http2: false in server options by `@Tony133` in https://github.com/fastify/fastify/pull/6888
* docs: clarify what attachValidation exposes on request.validationError by `@basteez` in https://github.com/fastify/fastify/pull/6891
* fix: do not force close in-flight connections when forceCloseConnections is 'idle' by `@aquie00t` in https://github.com/fastify/fastify/pull/6889

## New Contributors
* `@basteez` made their first contribution in https://github.com/fastify/fastify/pull/6891

**Full Changelog**: https://github.com/fastify/fastify/compare/v5.11.0...v5.11.1

[compare 5.11.0…5.11.2](https://github.com/fastify/fastify/compare/v5.11.0...v5.11.2) · [npm](https://www.npmjs.com/package/fastify/v/5.11.2)
</details>
