### PR TITLE
fix: accept fastify 5.x in the static-server logging plugin

### DIFF
--- a/packages/static-server/src/logs.ts
+++ b/packages/static-server/src/logs.ts
@@ -11,6 +11,6 @@ const plugin: FastifyPluginAsync = async (fastify): Promise<void> => {
 };
 
 export default fastifyPlugin(plugin, {
-	fastify: "4.x",
+	fastify: "5.x",
 	name: "fastify-simple-logger",
 });


### PR DESCRIPTION
## Problem

`static-server --logs` has been broken since the package moved to fastify 5.x. The `fastify-simple-logger` plugin still declared `fastify: "4.x"` in its `fastify-plugin` metadata, so the version check failed at boot and the server exited without ever serving:

```
fastify-plugin: fastify-simple-logger - expected '4.x' fastify version, '5.11.2' is installed
```

Every other flag works — only `--logs` is affected.

## Fix

One line: widen the declared range to `5.x`, matching what the package actually pins.

## Why it went unnoticed

`packages/static-server` has no `test` script and no tests (lerna runs `test` for 12 of 14 packages, this is one of the two skipped), so nothing exercised the flag.

## Verification

Built and ran the real binary:

```
$ node dist/server.js <dir> --port 8801 --logs
[...]: Server listening at http://127.0.0.1:8801
[...]: GET / 200
[...]: GET /nope 404
```

Before this change the same command printed the version-check error and served nothing. Full `pnpm build` + `pnpm lint` pass.

## Note for later

Unrelated, but fastify now warns that `disableRequestLogging` (used in `server.ts`) is deprecated and goes away in fastify 6 — worth handling before that major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bnTX3dzc8eVeb6Qfm51hv