### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/packages/static-server/package.json
+++ b/packages/static-server/package.json
@@ -33,7 +33,7 @@
 	},
 	"dependencies": {
 		"@fastify/caching": "9.0.3",
-		"@fastify/compress": "9.1.1",
+		"@fastify/compress": "9.2.0",
 		"@fastify/cors": "11.3.0",
 		"@fastify/static": "10.1.3",
 		"@node-cli/logger": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,8 +300,8 @@ importers:
         specifier: 9.0.3
         version: 9.0.3
       '@fastify/compress':
-        specifier: 9.1.1
-        version: 9.1.1
+        specifier: 9.2.0
+        version: 9.2.0
       '@fastify/cors':
         specifier: 11.3.0
         version: 11.3.0
@@ -732,8 +732,8 @@ packages:
   '@fastify/caching@9.0.3':
     resolution: {integrity: sha512-5K/2shYpvWHWiSAs59SaCVBoFhHEF8Yz4TTiXZf8YWVDcxuIxw0Adn5eDQ7s132s7vwURNOnCKHBjUQSOI+PLA==}
 
-  '@fastify/compress@9.1.1':
-    resolution: {integrity: sha512-YRv6HsKhI8TjdW/Etwo2GskrN8x5YaacSQhmeyc1dIgptvKPCFGRkXVciNvnCZULM1Np90b0TUM3D90l3VF1Zw==}
+  '@fastify/compress@9.2.0':
+    resolution: {integrity: sha512-35VL33PIEt/UbD/ZMlRNaICd2BQz0IaG7en74Dv7tI+MHIQkedibS1+9JfekWH4I1g+Y8RbbZD4Zsk9h4XTItg==}
 
   '@fastify/cors@11.3.0':
     resolution: {integrity: sha512-ggQGua+xHv1MvePbPr0v//xLYEsCXbWspquXCJS9Ot5YoRXq8J8ZWzHnxDBVnbtXosvistXo6LtNzOJswf64Fw==}
@@ -4785,7 +4785,7 @@ snapshots:
       fastify-plugin: 5.1.0
       uid-safe: 2.1.5
 
-  '@fastify/compress@9.1.1':
+  '@fastify/compress@9.2.0':
     dependencies:
       '@fastify/accept-negotiator': 2.0.1
       fastify-plugin: 6.0.0
@@ -5745,7 +5745,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.1.2
+      '@types/node': 26.2.0
     optional: true
 
   '@types/yargs-parser@21.0.3': {}
@@ -6133,7 +6133,7 @@ snapshots:
 
   buffer-image-size@0.6.4:
     dependencies:
-      '@types/node': 26.1.2
+      '@types/node': 26.2.0
     optional: true
 
   buffer@5.7.1:
@@ -6854,7 +6854,7 @@ snapshots:
 
   happy-dom@20.11.1:
     dependencies:
-      '@types/node': 26.1.2
+      '@types/node': 26.2.0
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       buffer-image-size: 0.6.4


### PR DESCRIPTION
Automated non-major dependency bump (deps-train).

**packages/static-server/package.json**
- @fastify/compress 9.1.1 → 9.2.0

---

### What changed

<details>
<summary><code>@fastify/compress</code> 9.1.1 → 9.2.0</summary>

#### [v9.2.0](https://github.com/fastify/fastify-compress/releases/tag/v9.2.0)

## What's Changed
* chore(.npmrc): add min-release-age by `@Fdawgs` in https://github.com/fastify/fastify-compress/pull/419
* perf: compress small buffered payloads synchronously by `@mcollina` in https://github.com/fastify/fastify-compress/pull/418
* chore: bump fastify/workflows/.github/workflows/lock-threads.yml from 6.0.0 to 7.0.0 by `@dependabot`[bot] in https://github.com/fastify/fastify-compress/pull/423
* chore: bump fastify/workflows/.github/workflows/plugins-ci.yml from 6.0.0 to 7.0.0 by `@dependabot`[bot] in https://github.com/fastify/fastify-compress/pull/422
* fix: unwrap fetch response before noCompress check for SSE support by `@priitkaard` in https://github.com/fastify/fastify-compress/pull/421


**Full Changelog**: https://github.com/fastify/fastify-compress/compare/v9.1.1...v9.2.0

[compare 9.1.1…9.2.0](https://github.com/fastify/fastify-compress/compare/v9.1.1...v9.2.0) · [npm](https://www.npmjs.com/package/@fastify/compress/v/9.2.0)
</details>
