### PR TITLE
fix(timer): restore Ctrl+C cancellation while the timer runs

### DIFF
--- a/packages/timer/src/utilities.ts
+++ b/packages/timer/src/utilities.ts
@@ -5,7 +5,18 @@ import { notify } from "./notify.js";
 import { Configuration } from "./parse.js";
 
 const logger = new Logger();
-const spinner = new Spinner();
+
+/**
+ * discardStdin must stay off. When it is on, ora puts stdin in raw mode, which
+ * stops the tty from turning Ctrl+C into SIGINT and delivers a bare 0x03 byte
+ * instead. stdin-discarder means to re-send the signal itself, but it attaches
+ * its reader with prependListener (which, unlike on("data"), does not start a
+ * paused stream flowing) and only calls resume() when stdin.isPaused() was true
+ * beforehand. On a fresh process.stdin, flowing is null, so isPaused() is false
+ * and the resume never happens: the byte is never read, the signal is never
+ * re-sent, and Ctrl+C is swallowed for the life of the spinner.
+ */
+const spinner = new Spinner({ discardStdin: false });
 
 const UNITS = {
 	ms: 1000,


### PR DESCRIPTION
## Problem

Ctrl+C stopped cancelling a running timer — the process had to be killed from another shell.

## Root cause

Upstream, in `stdin-discarder@0.3.2` by way of `ora@9.4.1` — not in our code.

When the spinner starts, ora puts stdin in **raw mode**. Raw mode stops the tty from turning Ctrl+C into SIGINT and delivers a bare `0x03` byte instead. `stdin-discarder` means to read that byte and re-send the signal itself, but it cannot:

- it attaches its reader with `prependListener("data", …)`, which — unlike `on("data")` — does **not** start a paused stream flowing;
- it only calls `resume()` when `stdin.isPaused()` was true beforehand. On a fresh `process.stdin`, `flowing` is `null`, so `isPaused()` returns **false** and the resume never happens.

The byte is never read, the signal is never re-sent, and the tty's own SIGINT is disabled. Ctrl+C is swallowed for the whole life of the spinner. Instrumentation shows it directly: `readableFlowing=null` with `data listeners=1` — a reader attached to a stream that never flows.

## Fix

One line, plus a comment so it doesn't get "cleaned up" later:

```ts
const spinner = new Spinner({ discardStdin: false });
```

ora then leaves the terminal in canonical mode and the kernel delivers a real SIGINT. `Spinner` already forwarded ora options, so `@node-cli/logger` needed no change. There is nothing to bump to instead — `ora@9.4.1` and `stdin-discarder@0.3.2` are both current.

## Verification

Driven under a real pty, since ora only sets raw mode when `isTTY`:

| | Result |
| --- | --- |
| Released 2.1.1 | **still alive 5s after Ctrl+C** |
| This branch | **exits in ~30ms, `signal=2`** |

- Interrupted at 0.3s, 1.0s, 2.0s and 3.5s into the timer — all cancel cleanly
- Cursor restored (`ESC[?25l` → `ESC[?25h`) and spinner line cleared on the way out
- Expiry path intact: `✔ Time's up!`, exit 0
- 15/15 timer tests; full suite green across 12 projects; `comments` reports unchanged

## Tradeoff

Keystrokes typed while the spinner runs are now echoed — that is what `discardStdin` suppressed. Ordinary CLI behavior, and the lesser cost against a timer that cannot be cancelled. Keeping the discard is not possible without the raw mode that causes the bug.

## Note

3 pre-existing lint warnings in `src/__tests__/utilities.test.ts` (unused imports) are untouched — separate PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5ssXq3kB2gv4wDANqjogQ